### PR TITLE
Now outputs a struct that wraps `GenerationInputs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,10 @@ dependencies = [
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "eth-trie-utils",
+ "plonky2_evm",
  "pretty_env_logger",
+ "serde",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "3ca443fd18e3f6d209dd96cbad851e05ae058b34" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b" }
 pretty_env_logger = "0.4.0"
+serde = {version = "1.0.144", features = ["derive"] }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,1 +1,14 @@
+use eth_trie_utils::partial_trie::PartialTrie;
+use plonky2_evm::generation::GenerationInputs;
+use serde::{Deserialize, Serialize};
+
 pub const PARSED_TESTS_PATH: &str = "parsed_tests";
+
+/// A parsed JSON Ethereum test that is ready to be fed into `Plonky2`.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ParsedTest {
+    pub plonky2_inputs: GenerationInputs,
+
+    /// If the test specifies a final account trie state, this will be filled.
+    pub expected_final_account_states: Option<PartialTrie>,
+}

--- a/eth_test_parser/src/eth_test_parsing.rs
+++ b/eth_test_parser/src/eth_test_parsing.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use anyhow::Context;
+use common::types::ParsedTest;
 use log::{debug, info};
 use plonky2_evm::generation::GenerationInputs;
 use serde_json::Value;
@@ -132,7 +133,7 @@ fn extract_relevant_fields(
     }
 }
 
-fn process_extracted_fields(fields: ExtractedWhitelistedJson) -> anyhow::Result<GenerationInputs> {
+fn process_extracted_fields(fields: ExtractedWhitelistedJson) -> anyhow::Result<ParsedTest> {
     let account_info = parse_initial_account_state_from_json(&fields[ACCOUNTS_JSON_FIELD])?;
     let receipts_trie = parse_receipt_trie_from_json(&fields[RECEIPTS_JSON_FIELD]);
     let txn_info = parse_txn_trie_from_json(&fields[BLOCKS_JSON_FIELD]);
@@ -141,13 +142,21 @@ fn process_extracted_fields(fields: ExtractedWhitelistedJson) -> anyhow::Result<
         &fields[GENESIS_BLOCK_JSON_FIELD],
     );
 
-    Ok(GenerationInputs {
+    let plonky2_inputs = GenerationInputs {
         signed_txns: txn_info.signed_txns,
         state_trie: account_info.account_trie,
         transactions_trie: txn_info.txn_trie,
         receipts_trie,
         storage_tries: account_info.account_storage_tries,
         block_metadata,
+    };
+
+    // TODO: Parse from the `Post` JSON field if present...
+    let expected_final_account_states = None;
+
+    Ok(ParsedTest {
+        plonky2_inputs,
+        expected_final_account_states,
     })
 }
 


### PR DESCRIPTION
Realized that there is also additional data related to the test that `Plonky2` does not care about.