### PR TITLE
Specify nightly via rust-toolchain for plonky2 compatibility

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Build fails unless Rust is on the nightly channel due to plonky2's usage of `#![feature]`.

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/845717/191601252-2a13c6a1-e538-433c-a502-f56ce3d431dd.png">
