### PR TITLE
Allow deserializing without fetching git remote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,13 +172,28 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 4.0.13",
+ "clap_lex 0.3.0",
+ "once_cell",
+ "strsim",
+ "termcolor",
 ]
 
 [[package]]
@@ -195,10 +210,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -438,7 +475,7 @@ name = "eth_test_parser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 4.0.14",
  "common",
  "eth-trie-utils",
  "ethereum-types",
@@ -484,7 +521,7 @@ name = "evm_test_runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
+ "clap 3.2.22",
  "common",
  "eth-trie-utils",
  "ethereum-types",

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -12,7 +12,7 @@ common = { path = "../common" }
 plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b" }
 eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "3ca443fd18e3f6d209dd96cbad851e05ae058b34" }
 
-clap = {version = "3.2.17", features = ["derive"] }
+clap = {version = "4.0.14", features = ["derive"] }
 anyhow = { version = "1.0", features = ["backtrace"] }
 log = "0.4.17"
 serde_json = "1.0.86"

--- a/eth_test_parser/src/arg_parsing.rs
+++ b/eth_test_parser/src/arg_parsing.rs
@@ -1,5 +1,9 @@
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
-pub(crate) struct ProgArgs {}
+#[command(author, version, about)]
+pub(crate) struct ProgArgs {
+    // #[arg(short, long, default_value_t = false)]
+    #[arg(short, long, default_value_t = false)]
+    pub no_fetch: bool,
+}

--- a/eth_test_parser/src/arg_parsing.rs
+++ b/eth_test_parser/src/arg_parsing.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
 pub(crate) struct ProgArgs {
-    // #[arg(short, long, default_value_t = false)]
     #[arg(short, long, default_value_t = false)]
+    /// Allow deserializing without fetching git remote
     pub no_fetch: bool,
 }

--- a/eth_test_parser/src/main.rs
+++ b/eth_test_parser/src/main.rs
@@ -15,28 +15,21 @@ mod fs_scaffolding;
 mod trie_builder;
 mod utils;
 
-pub(crate) struct ProgState {}
-
-impl ProgState {
-    fn new(_: ProgArgs) -> Self {
-        Self {}
-    }
-}
-
 fn main() -> Result<()> {
     init_env_logger();
     let p_args = ProgArgs::parse();
-    let state = ProgState::new(p_args);
 
-    run(state)
+    run(p_args)
 }
 
-fn run(_: ProgState) -> Result<()> {
-    // Fetch most recent test json.
-    clone_or_update_remote_tests();
+fn run(ProgArgs { no_fetch }: ProgArgs) -> Result<()> {
+    if !no_fetch {
+        // Fetch most recent test json.
+        clone_or_update_remote_tests();
 
-    // Create output directories mirroring the structure of source tests.
-    prepare_output_dir()?;
+        // Create output directories mirroring the structure of source tests.
+        prepare_output_dir()?;
+    }
 
     // TODO: Use deserialized test structs to construct plonky2 generation inputs.
     for (test_dir_entry, test_body) in get_deserialized_test_bodies()? {


### PR DESCRIPTION
Add a flag (`--no-fetch`) which allows invoking deserialization _without_ fetching the git remote beforehand.


Also bump `clap` to `4.0.14`.