### PR TITLE
Runner result rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "coolor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4d7a805ca0d92f8c61a31c809d4323fdaa939b0b440e544d21db7797c5aaad"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +292,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -320,12 +343,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -538,6 +596,7 @@ dependencies = [
  "plonky2",
  "plonky2_evm",
  "serde_json",
+ "termimad",
  "tokio",
  "tokio-stream",
 ]
@@ -804,6 +863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "277639f0198568f70f8fe4ab88a52a67c96bca12f27ba5c17a76acdcb8b45834"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +942,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1018,6 +1108,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1302,6 +1415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1580,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +1651,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termimad"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3977554523f42b473e5211e5fbb39e78e21e793ff6ffd6428ae3bd02dbb7e09d"
+dependencies = [
+ "coolor",
+ "crossbeam",
+ "crossterm",
+ "minimad",
+ "thiserror",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1730,6 +1902,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "askama"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb98f10f371286b177db5eeb9a6e5396609555686a35e1d4f7b9a9c6d8af0139"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "askama_shared",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87bf87e6e8b47264efa9bde63d6225c6276a52e05e91bf37eaa8afd0032d6b71"
+dependencies = [
+ "askama_shared",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_shared"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf722b94118a07fcbc6640190f247334027685d4e218b794dbfe17c32bf38ed0"
+dependencies = [
+ "askama_escape",
+ "humansize",
+ "mime",
+ "mime_guess",
+ "nom",
+ "num-traits",
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,9 +569,9 @@ name = "evm_test_runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
  "clap 3.2.22",
  "common",
- "eth-trie-utils",
  "ethereum-types",
  "log",
  "plonky2",
@@ -628,6 +676,12 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
@@ -821,12 +875,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -972,6 +1058,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
@@ -1554,6 +1646,15 @@ dependencies = [
  "crunchy",
  "hex",
  "static_assertions",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,47 +214,17 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 4.0.13",
- "clap_lex 0.3.0",
+ "clap_derive",
+ "clap_lex",
  "once_cell",
  "strsim",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -268,15 +238,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -523,7 +484,7 @@ name = "eth_test_parser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 4.0.14",
+ "clap",
  "common",
  "eth-trie-utils",
  "ethereum-types",
@@ -570,7 +531,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "askama",
- "clap 3.2.22",
+ "clap",
  "common",
  "ethereum-types",
  "log",
@@ -1533,12 +1494,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 name = "common"
 version = "0.1.0"
 dependencies = [
- "eth-trie-utils",
+ "eth_trie_utils",
  "ethereum-types",
  "plonky2_evm",
  "pretty_env_logger",
@@ -524,27 +524,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "eth-trie-utils"
-version = "0.1.0"
-source = "git+https://github.com/mir-protocol/eth-trie-utils.git?rev=3ca443fd18e3f6d209dd96cbad851e05ae058b34#3ca443fd18e3f6d209dd96cbad851e05ae058b34"
-dependencies = [
- "anyhow",
- "ethereum-types",
- "hex",
- "itertools",
- "log",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "eth_test_parser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
  "common",
- "eth-trie-utils",
+ "eth_trie_utils",
  "ethereum-types",
  "hex",
  "log",
@@ -553,17 +539,35 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_with",
- "sha3",
+]
+
+[[package]]
+name = "eth_trie_utils"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84370e45d90ca73c10363c1269b29c1e0967c02ed2ec407c2970ad095523adf"
+dependencies = [
+ "bytes",
+ "ethereum-types",
+ "hex",
+ "itertools",
+ "keccak-hash 0.10.0",
+ "log",
+ "num-traits",
+ "rlp",
+ "serde",
+ "thiserror",
+ "uint",
 ]
 
 [[package]]
 name = "ethbloom"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.8.0",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak",
@@ -571,15 +575,15 @@ dependencies = [
 
 [[package]]
 name = "ethereum-types"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+checksum = "81224dc661606574f5a0f28c9947d0ee1d93ff11c5f1c4e7272f52e8c0b5483c"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.8.0",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.0",
  "uint",
 ]
 
@@ -606,6 +610,15 @@ name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand",
@@ -768,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -808,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "js-sys"
@@ -820,12 +833,6 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "keccak"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
 name = "keccak-hash"
@@ -848,10 +855,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.134"
+name = "keccak-hash"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "4b286e6b663fb926e1eeb68528e69cb70ed46c6d65871a21b2215ae8154c6d3c"
+dependencies = [
+ "primitive-types 0.12.0",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.135"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "link-cplusplus"
@@ -884,7 +901,7 @@ dependencies = [
 [[package]]
 name = "maybe_rayon"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=928e8bc0e90507b5aeee2900a266bfc02dadb05b#928e8bc0e90507b5aeee2900a266bfc02dadb05b"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=06475c2b61a0d3b26d3f3ded791456052b94251b#06475c2b61a0d3b26d3f3ded791456052b94251b"
 dependencies = [
  "rayon",
 ]
@@ -1141,9 +1158,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb779fcf4bb850fbbb0edc96ff6cf34fd90c4b1a112ce042653280d9a7364048"
+checksum = "dbc7bc69c062e492337d74d59b120c274fd3d261b6bf6d3207d499b4b379c41a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1151,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502b62a6d0245378b04ffe0a7fb4f4419a4815fce813bd8a0ec89a56e07d67b1"
+checksum = "60b75706b9642ebcb34dab3bc7750f811609a0eb1dd8b88c2d15bf628c1c65b2"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1161,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451e629bf49b750254da26132f1a5a9d11fd8a95a3df51d15c4abd1ba154cb6c"
+checksum = "f4f9272122f5979a6511a749af9db9bfc810393f63119970d7085fed1c4ea0db"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1174,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec162c71c45e269dfc3fc2916eaeb97feab22993a21bcce4721d08cd7801a6"
+checksum = "4c8717927f9b79515e565a64fe46c38b8cd0427e64c40680b14a7365ab09ac8d"
 dependencies = [
  "once_cell",
  "pest",
@@ -1192,7 +1209,7 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 [[package]]
 name = "plonky2"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=928e8bc0e90507b5aeee2900a266bfc02dadb05b#928e8bc0e90507b5aeee2900a266bfc02dadb05b"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=06475c2b61a0d3b26d3f3ded791456052b94251b#06475c2b61a0d3b26d3f3ded791456052b94251b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1213,17 +1230,18 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=928e8bc0e90507b5aeee2900a266bfc02dadb05b#928e8bc0e90507b5aeee2900a266bfc02dadb05b"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=06475c2b61a0d3b26d3f3ded791456052b94251b#06475c2b61a0d3b26d3f3ded791456052b94251b"
 dependencies = [
  "anyhow",
  "env_logger 0.9.1",
- "eth-trie-utils",
+ "eth_trie_utils",
  "ethereum-types",
  "hex-literal",
  "itertools",
  "keccak-hash 0.9.0",
  "log",
  "maybe_rayon",
+ "num",
  "once_cell",
  "pest",
  "pest_derive",
@@ -1231,15 +1249,18 @@ dependencies = [
  "plonky2_util",
  "rand",
  "rand_chacha",
+ "ripemd",
  "rlp",
+ "rlp-derive",
  "serde",
+ "sha2",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "plonky2_field"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=928e8bc0e90507b5aeee2900a266bfc02dadb05b#928e8bc0e90507b5aeee2900a266bfc02dadb05b"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=06475c2b61a0d3b26d3f3ded791456052b94251b#06475c2b61a0d3b26d3f3ded791456052b94251b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1254,7 +1275,7 @@ dependencies = [
 [[package]]
 name = "plonky2_util"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=928e8bc0e90507b5aeee2900a266bfc02dadb05b#928e8bc0e90507b5aeee2900a266bfc02dadb05b"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=06475c2b61a0d3b26d3f3ded791456052b94251b#06475c2b61a0d3b26d3f3ded791456052b94251b"
 
 [[package]]
 name = "ppv-lite86"
@@ -1278,7 +1299,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "uint",
 ]
 
@@ -1288,7 +1309,17 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.7.0",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cfd65aea0c5fa0bfcc7c9e7ca828c921ef778f43d325325ec84bda371bfa75a"
+dependencies = [
+ "fixed-hash 0.8.0",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
@@ -1441,6 +1472,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1488,17 @@ checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1570,13 +1621,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha3"
-version = "0.10.5"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2904bea16a1ae962b483322a1c7b81d976029203aea1f461e51cd7705db7ba9"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
+ "cfg-if",
+ "cpufeatures",
  "digest",
- "keccak",
 ]
 
 [[package]]
@@ -1629,9 +1681,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1733,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1786,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-width"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "3ca443fd18e3f6d209dd96cbad851e05ae058b34" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b" }
+eth_trie_utils = "0.2.1"
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "06475c2b61a0d3b26d3f3ded791456052b94251b" }
 
-ethereum-types = "0.13.1"
+ethereum-types = "0.14.0"
 pretty_env_logger = "0.4.0"
-serde = {version = "1.0.144", features = ["derive"] }
+serde = {version = "1.0.145", features = ["derive"] }

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -9,16 +9,15 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b" }
-eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "3ca443fd18e3f6d209dd96cbad851e05ae058b34" }
+eth_trie_utils = "0.2.1"
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "06475c2b61a0d3b26d3f3ded791456052b94251b" }
 
+anyhow = { version = "1.0.65", features = ["backtrace"] }
 clap = {version = "4.0.14", features = ["derive"] }
-anyhow = { version = "1.0", features = ["backtrace"] }
+ethereum-types = "0.14.0"
+hex = "0.4.3"
 log = "0.4.17"
-serde_json = "1.0.86"
 serde = "1.0.145"
 serde_bytes = "0.11.7"
+serde_json = "1.0.86"
 serde_with = "2.0.1"
-ethereum-types = "0.13.1"
-hex = "0.4.3"
-sha3 = "0.10.4"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 common = { path = "../common" }
 plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b" }
 plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b", features = ["timing"] }
-eth-trie-utils = { git = "https://github.com/mir-protocol/eth-trie-utils.git", rev = "3ca443fd18e3f6d209dd96cbad851e05ae058b34" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 clap = {version = "3.2.17", features = ["derive"] }
@@ -21,3 +20,4 @@ log = "0.4.17"
 serde_json = "1.0.85"
 tokio = {version = "1.21.1", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-stream = {version  = "0.1.10", features = ["fs"] }
+askama = "0.11.1"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -13,7 +13,7 @@ plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e
 plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b", features = ["timing"] }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
-clap = {version = "3.2.17", features = ["derive"] }
+clap = {version = "4.0.10", features = ["derive"] }
 
 ethereum-types = "0.13.1"
 log = "0.4.17"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,16 +9,15 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0e90507b5aeee2900a266bfc02dadb05b", features = ["timing"] }
+plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "06475c2b61a0d3b26d3f3ded791456052b94251b", features = ["timing"] }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "06475c2b61a0d3b26d3f3ded791456052b94251b" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
-clap = {version = "4.0.10", features = ["derive"] }
-
 askama = "0.11.1"
-ethereum-types = "0.13.1"
+clap = {version = "4.0.14", features = ["derive"] }
+ethereum-types = "0.14.0"
 log = "0.4.17"
-serde_json = "1.0.85"
+serde_json = "1.0.86"
 termimad = "0.20.3"
-tokio = {version = "1.21.1", features = ["fs", "macros", "rt-multi-thread"] }
-tokio-stream = {version  = "0.1.10", features = ["fs"] }
+tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread"] }
+tokio-stream = {version  = "0.1.11", features = ["fs"] }

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -15,9 +15,10 @@ plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "928e8bc0
 anyhow = { version = "1.0", features = ["backtrace"] }
 clap = {version = "4.0.10", features = ["derive"] }
 
+askama = "0.11.1"
 ethereum-types = "0.13.1"
 log = "0.4.17"
 serde_json = "1.0.85"
+termimad = "0.20.3"
 tokio = {version = "1.21.1", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-stream = {version  = "0.1.10", features = ["fs"] }
-askama = "0.11.1"

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -1,14 +1,34 @@
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum RunCommand {
+    /// Run tests (with an optional filter) and only print to stdout.
+    Test(TestArgs),
+
+    /// Run all tests and generate a report summary markdown file.
+    Report,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct TestArgs {
+    /// An optional filter to only run tests that are a subset of the given test
+    /// path.
+    pub(crate) test_filter: Option<String>,
+}
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
 pub(crate) struct ProgArgs {
-    /// Write the output from running the tests to a markdown file.
-    #[clap(short = 'm', action)]
-    pub(crate) output_result_markdown: bool,
-
     /// The path to the parsed tests directory.
     pub(crate) parsed_tests_path: PathBuf,
+
+    /// The command to run.
+    #[command(subcommand)]
+    pub(crate) cmd: RunCommand,
+}
+
+pub(crate) fn parse_prog_args() -> ProgArgs {
+    ProgArgs::parse()
 }

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -1,21 +1,17 @@
 use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Parser, ValueEnum};
 
-#[derive(Debug, Subcommand)]
-pub(crate) enum RunCommand {
-    /// Run tests (with an optional filter) and only print to stdout.
-    Test(TestArgs),
+#[derive(Clone, Debug, ValueEnum)]
+pub(crate) enum ReportType {
+    /// Run tests (flatten, no groups) and render markdown to stdout. Displays
+    /// detailed information for each individual test.
+    Test,
 
-    /// Run all tests and generate a report summary markdown file.
-    Report,
-}
-
-#[derive(Args, Debug)]
-pub(crate) struct TestArgs {
-    /// An optional filter to only run tests that are a subset of the given test
-    /// path.
-    pub(crate) test_filter: Option<String>,
+    /// Run all tests and write a high-level markdown report summary to disk.
+    /// The summary does not contain information on individual tests and instead
+    /// aggregates all of the tests in a sub-group into row entries.
+    Summary,
 }
 
 #[derive(Debug, Parser)]
@@ -24,7 +20,12 @@ pub(crate) struct ProgArgs {
     /// The path to the parsed tests directory.
     pub(crate) parsed_tests_path: PathBuf,
 
-    /// The command to run.
-    #[command(subcommand)]
-    pub(crate) cmd: RunCommand,
+    #[arg(short='r', long, value_enum, default_value_t=ReportType::Test)]
+    /// The type of report to generate.
+    pub(crate) report_type: ReportType,
+
+    #[arg(short = 'f', long)]
+    /// An optional filter to only run tests that are a subset of the given
+    /// test path.
+    pub(crate) test_filter: Option<String>,
 }

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -28,7 +28,3 @@ pub(crate) struct ProgArgs {
     #[command(subcommand)]
     pub(crate) cmd: RunCommand,
 }
-
-pub(crate) fn parse_prog_args() -> ProgArgs {
-    ProgArgs::parse()
-}

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -6,11 +6,11 @@ use log::info;
 use plonky2_runner::run_plonky2_tests;
 use test_dir_reading::read_in_all_parsed_tests;
 
-use crate::markdown_generation::write_test_results_markdown_to_file;
+use crate::report_generation::write_overall_status_report_summary_to_file;
 
 mod arg_parsing;
-mod markdown_generation;
 mod plonky2_runner;
+mod report_generation;
 mod test_dir_reading;
 
 #[tokio::main()]
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
 
     if p_args.output_result_markdown {
         info!("Generating test results markdown...");
-        write_test_results_markdown_to_file(&test_res);
+        write_overall_status_report_summary_to_file(test_res);
     }
 
     Ok(())

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(let_chains)]
 
-use arg_parsing::{parse_prog_args, RunCommand};
+use arg_parsing::{ProgArgs, RunCommand};
+use clap::Parser;
 use log::info;
 use plonky2_runner::run_plonky2_tests;
 use report_generation::output_test_report_for_terminal;
@@ -15,14 +16,14 @@ mod test_dir_reading;
 
 #[tokio::main()]
 async fn main() -> anyhow::Result<()> {
-    let p_args = parse_prog_args();
+    let p_args = ProgArgs::parse();
 
     let filter = match &p_args.cmd {
         RunCommand::Test(filter) => &filter.test_filter,
         RunCommand::Report => &None,
     };
 
-    let parsed_tests = read_in_all_parsed_tests(&p_args.parsed_tests_path, filter.as_ref()).await?;
+    let parsed_tests = read_in_all_parsed_tests(&p_args.parsed_tests_path, filter.clone()).await?;
     let test_res = run_plonky2_tests(parsed_tests);
 
     match p_args.cmd {

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
     match p_args.cmd {
         RunCommand::Test(_) => {
             info!("Outputting test results to stdout...");
-            output_test_report_for_terminal(test_res);
+            output_test_report_for_terminal(&test_res, filter.clone());
         }
         RunCommand::Report => {
             info!("Generating test results markdown...");

--- a/evm_test_runner/src/markdown_generation.rs
+++ b/evm_test_runner/src/markdown_generation.rs
@@ -1,5 +1,0 @@
-//! Generates a markdown report from test results.
-
-use crate::plonky2_runner::TestGroupRunResults;
-
-pub(crate) fn write_test_results_markdown_to_file(_res: &[TestGroupRunResults]) {}

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -13,12 +13,18 @@ use plonky2_evm::{all_stark::AllStark, config::StarkConfig, prover::prove};
 
 use crate::test_dir_reading::{ParsedTestGroup, ParsedTestSubGroup, Test};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum TestStatus {
     Passed,
     EvmErr(String),
     EvmPanic(String),
     IncorrectAccountFinalState(H256, H256),
+}
+
+impl TestStatus {
+    pub(crate) fn passed(&self) -> bool {
+        matches!(self, TestStatus::Passed)
+    }
 }
 
 #[derive(Debug)]

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -1,5 +1,5 @@
 //! Handles feeding the parsed tests into `plonky2` and determining the result.
-//! Essentially converts parsed test into test results.
+//! Essentially converts parsed tests into test results.
 
 use std::{fmt::Display, panic};
 

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -4,7 +4,7 @@
 use std::{fmt::Display, panic};
 
 use common::types::ParsedTest;
-use ethereum_types::{BigEndianHash, H256};
+use ethereum_types::H256;
 use plonky2::{
     field::goldilocks_field::GoldilocksField, plonk::config::KeccakGoldilocksConfig,
     util::timing::TimingTree,
@@ -137,15 +137,11 @@ fn run_test_and_get_test_result(test: ParsedTest) -> TestStatus {
         }
     };
 
-    // TODO: Remove `U256` --> `H256` conversion once `plonky2` switches over to
-    // `H256`...
-    let final_state_trie_hash = H256::from_uint(&ethereum_types::U256(
-        proof_run_output.public_values.trie_roots_after.state_root.0,
-    ));
+    let actual_state_trie_hash = proof_run_output.public_values.trie_roots_after.state_root;
 
-    if let Some(expected_state_trie_hash) = test.expected_final_account_states && final_state_trie_hash != expected_state_trie_hash {
+    if let Some(expected_state_trie_hash) = test.expected_final_account_states && actual_state_trie_hash != expected_state_trie_hash {
         let trie_diff = TrieFinalStateDiff {
-            state: TrieComparisonResult::Difference(final_state_trie_hash, expected_state_trie_hash),
+            state: TrieComparisonResult::Difference(actual_state_trie_hash, expected_state_trie_hash),
             receipt: TrieComparisonResult::Correct, // TODO...
             transaction: TrieComparisonResult::Correct, // TODO...
         };

--- a/evm_test_runner/src/report_generation.rs
+++ b/evm_test_runner/src/report_generation.rs
@@ -1,0 +1,134 @@
+//! Report generation.
+//!
+//! Supports reports in both markdown and output for the terminal.
+
+use std::{fs, path::Path};
+
+use askama::Template;
+
+use crate::plonky2_runner::{
+    TestGroupRunResults, TestRunResult, TestStatus, TestSubGroupRunResults,
+};
+
+const REPORT_OUTPUT: &str = "reports";
+
+#[derive(Debug, Template)]
+#[template(path = "test_results_summary.md")]
+struct TestResultsSummaryTemplate {
+    groups: Vec<TemplateGroupResultsData>,
+}
+
+impl From<Vec<TestGroupRunResults>> for TestResultsSummaryTemplate {
+    fn from(v: Vec<TestGroupRunResults>) -> Self {
+        Self {
+            groups: v.into_iter().map(|g| g.into()).collect(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TemplateGroupResultsData {
+    name: String,
+    passed_info: TemplateTestPassedInfo,
+    sub_groups: Vec<TemplateSubGroupResultsData>,
+}
+
+impl From<TestGroupRunResults> for TemplateGroupResultsData {
+    fn from(v: TestGroupRunResults) -> Self {
+        let sub_groups: Vec<TemplateSubGroupResultsData> =
+            v.sub_group_res.into_iter().map(|g| g.into()).collect();
+        let (tot_tests, num_passed) =
+            sub_groups
+                .iter()
+                .fold((0, 0), |(tot_tests, num_passed), sub_g| {
+                    (
+                        tot_tests + sub_g.passed_info.tot_tests,
+                        num_passed + sub_g.passed_info.num_passed,
+                    )
+                });
+        let passed_info = TemplateTestPassedInfo::new(tot_tests, num_passed);
+
+        Self {
+            name: v.name,
+            passed_info,
+            sub_groups,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TemplateSubGroupResultsData {
+    name: String,
+    passed_info: TemplateTestPassedInfo,
+    tests: Vec<TemplateTestResultData>,
+}
+
+impl From<TestSubGroupRunResults> for TemplateSubGroupResultsData {
+    fn from(v: TestSubGroupRunResults) -> Self {
+        let tests: Vec<TemplateTestResultData> = v.test_res.into_iter().map(|t| t.into()).collect();
+        let num_passed = tests
+            .iter()
+            .filter(|t| matches!(t.status, TestStatus::Passed))
+            .count();
+        let passed_info = TemplateTestPassedInfo::new(tests.len(), num_passed);
+
+        Self {
+            name: v.name,
+            passed_info,
+            tests,
+        }
+    }
+}
+
+// TODO: Consider removing if there are no different fields from
+// `TestRunResult`...
+#[derive(Debug)]
+struct TemplateTestResultData {
+    name: String,
+    status: TestStatus,
+}
+
+impl From<TestRunResult> for TemplateTestResultData {
+    fn from(v: TestRunResult) -> Self {
+        Self {
+            name: v.name,
+            status: v.status,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TemplateTestPassedInfo {
+    tot_tests: usize,
+    num_passed: usize,
+    perc_passed: String,
+}
+
+impl TemplateTestPassedInfo {
+    fn new(tot_tests: usize, num_passed: usize) -> Self {
+        let perc_passed = format!("{:2}%", num_passed as f32 / tot_tests as f32);
+
+        Self {
+            tot_tests,
+            num_passed,
+            perc_passed,
+        }
+    }
+}
+
+pub(crate) fn output_test_report_for_terminal(_res: Vec<TestGroupRunResults>) {
+    todo!()
+}
+
+pub(crate) fn write_overall_status_report_summary_to_file(
+    res: Vec<TestGroupRunResults>,
+) -> anyhow::Result<()> {
+    let overall_summary_template: TestResultsSummaryTemplate = res.into();
+    let report = overall_summary_template
+        .render()
+        .expect("Error rendering report markdown");
+    let summary_path = Path::new(&REPORT_OUTPUT).join("summary.md");
+
+    fs::write(summary_path, report)?;
+    Ok(())
+}

--- a/evm_test_runner/src/report_generation.rs
+++ b/evm_test_runner/src/report_generation.rs
@@ -13,6 +13,55 @@ use crate::plonky2_runner::{
 const REPORT_OUTPUT: &str = "reports";
 
 #[derive(Debug, Template)]
+#[template(path = "filtered_test_results.md")]
+struct FilteredTestResultsTemplate {
+    filter_str_template: String,
+    passed_info: PassedInfo,
+    tests: Vec<TestRunResult>,
+}
+
+impl TestGroupRunResults {
+    /// Flattens all test groups/subgroups into individual tests using their
+    /// full paths as the test name.
+    fn flatten_tests(&self) -> impl Iterator<Item = TestRunResult> + '_ {
+        self.sub_group_res.iter().flat_map(move |sub_g| {
+            sub_g.test_res.iter().map(move |test| {
+                let full_path = Path::new(&self.name).join(&sub_g.name).join(&test.name);
+
+                TestRunResult {
+                    name: full_path.to_str().unwrap().to_string(),
+                    status: test.status.clone(),
+                }
+            })
+        })
+    }
+}
+
+impl FilteredTestResultsTemplate {
+    fn new(res: &[TestGroupRunResults], filter_str_template: &Option<String>) -> Self {
+        let tests = res.iter().flat_map(|g| g.flatten_tests());
+
+        let filtered_tests: Vec<_> = match filter_str_template {
+            Some(filter_str) => tests.filter(|t| t.name.contains(filter_str)).collect(),
+            None => tests.collect(),
+        };
+
+        let num_passed = filtered_tests.iter().filter(|t| t.status.passed()).count();
+
+        let filter_str_template = match filter_str_template {
+            Some(filter_str) => format!("({})", filter_str),
+            None => "".to_string(),
+        };
+
+        Self {
+            filter_str_template,
+            passed_info: PassedInfo::new(filtered_tests.len(), num_passed),
+            tests: filtered_tests,
+        }
+    }
+}
+
+#[derive(Debug, Template)]
 #[template(path = "test_results_summary.md")]
 struct TestResultsSummaryTemplate {
     groups: Vec<TemplateGroupResultsData>,
@@ -29,7 +78,7 @@ impl From<Vec<TestGroupRunResults>> for TestResultsSummaryTemplate {
 #[derive(Debug)]
 struct TemplateGroupResultsData {
     name: String,
-    passed_info: TemplateTestPassedInfo,
+    passed_info: PassedInfo,
     sub_groups: Vec<TemplateSubGroupResultsData>,
 }
 
@@ -46,7 +95,7 @@ impl From<TestGroupRunResults> for TemplateGroupResultsData {
                         num_passed + sub_g.passed_info.num_passed,
                     )
                 });
-        let passed_info = TemplateTestPassedInfo::new(tot_tests, num_passed);
+        let passed_info = PassedInfo::new(tot_tests, num_passed);
 
         Self {
             name: v.name,
@@ -59,52 +108,34 @@ impl From<TestGroupRunResults> for TemplateGroupResultsData {
 #[derive(Debug)]
 struct TemplateSubGroupResultsData {
     name: String,
-    passed_info: TemplateTestPassedInfo,
-    tests: Vec<TemplateTestResultData>,
+    passed_info: PassedInfo,
 }
 
 impl From<TestSubGroupRunResults> for TemplateSubGroupResultsData {
     fn from(v: TestSubGroupRunResults) -> Self {
-        let tests: Vec<TemplateTestResultData> = v.test_res.into_iter().map(|t| t.into()).collect();
+        let tests: Vec<TestRunResult> = v.test_res.into_iter().collect();
         let num_passed = tests
             .iter()
             .filter(|t| matches!(t.status, TestStatus::Passed))
             .count();
-        let passed_info = TemplateTestPassedInfo::new(tests.len(), num_passed);
+
+        let passed_info = PassedInfo::new(tests.len(), num_passed);
 
         Self {
             name: v.name,
             passed_info,
-            tests,
-        }
-    }
-}
-
-// TODO: Consider removing if there are no different fields from
-// `TestRunResult`...
-#[derive(Debug)]
-struct TemplateTestResultData {
-    name: String,
-    status: TestStatus,
-}
-
-impl From<TestRunResult> for TemplateTestResultData {
-    fn from(v: TestRunResult) -> Self {
-        Self {
-            name: v.name,
-            status: v.status,
         }
     }
 }
 
 #[derive(Debug)]
-struct TemplateTestPassedInfo {
+struct PassedInfo {
     tot_tests: usize,
     num_passed: usize,
     perc_passed: String,
 }
 
-impl TemplateTestPassedInfo {
+impl PassedInfo {
     fn new(tot_tests: usize, num_passed: usize) -> Self {
         let perc_passed = format!("{:2}%", num_passed as f32 / tot_tests as f32);
 
@@ -116,8 +147,16 @@ impl TemplateTestPassedInfo {
     }
 }
 
-pub(crate) fn output_test_report_for_terminal(_res: Vec<TestGroupRunResults>) {
-    todo!()
+pub(crate) fn output_test_report_for_terminal(
+    res: &[TestGroupRunResults],
+    test_filter_str: Option<String>,
+) {
+    let filtered_tests_output_template = FilteredTestResultsTemplate::new(res, &test_filter_str);
+    let report = filtered_tests_output_template
+        .render()
+        .expect("Error rendering filtered test output markdown");
+
+    termimad::print_text(&report);
 }
 
 pub(crate) fn write_overall_status_report_summary_to_file(
@@ -126,7 +165,8 @@ pub(crate) fn write_overall_status_report_summary_to_file(
     let overall_summary_template: TestResultsSummaryTemplate = res.into();
     let report = overall_summary_template
         .render()
-        .expect("Error rendering report markdown");
+        .expect("Error rendering summary report markdown");
+
     let summary_path = Path::new(&REPORT_OUTPUT).join("summary.md");
 
     fs::write(summary_path, report)?;

--- a/evm_test_runner/src/test_dir_reading.rs
+++ b/evm_test_runner/src/test_dir_reading.rs
@@ -40,6 +40,7 @@ pub(crate) struct Test {
 /// Reads in all parsed tests from the given parsed test directory.
 pub(crate) async fn read_in_all_parsed_tests(
     parsed_tests_path: &Path,
+    _filter: Option<&String>,
 ) -> anyhow::Result<Vec<ParsedTestGroup>> {
     let (mut groups, mut join_set, mut read_dirs) =
         parse_dir_init(Path::new(parsed_tests_path)).await?;

--- a/evm_test_runner/src/test_dir_reading.rs
+++ b/evm_test_runner/src/test_dir_reading.rs
@@ -40,7 +40,7 @@ pub(crate) struct Test {
 /// Reads in all parsed tests from the given parsed test directory.
 pub(crate) async fn read_in_all_parsed_tests(
     parsed_tests_path: &Path,
-    _filter: Option<&String>,
+    filter_str: Option<String>,
 ) -> anyhow::Result<Vec<ParsedTestGroup>> {
     let (mut groups, mut join_set, mut read_dirs) =
         parse_dir_init(Path::new(parsed_tests_path)).await?;
@@ -52,7 +52,7 @@ pub(crate) async fn read_in_all_parsed_tests(
             continue;
         }
 
-        join_set.spawn(parse_test_group(entry.path()));
+        join_set.spawn(parse_test_group(entry.path(), filter_str.clone()));
     }
 
     wait_for_task_to_finish_and_push_to_vec(&mut join_set, &mut groups).await?;
@@ -60,7 +60,10 @@ pub(crate) async fn read_in_all_parsed_tests(
     Ok(groups)
 }
 
-async fn parse_test_group(path: PathBuf) -> anyhow::Result<ParsedTestGroup> {
+async fn parse_test_group(
+    path: PathBuf,
+    filter_str: Option<String>,
+) -> anyhow::Result<ParsedTestGroup> {
     info!("Reading in test group {:?}...", path);
     let (mut sub_groups, mut join_set, mut read_dirs) = parse_dir_init(&path).await?;
 
@@ -71,7 +74,10 @@ async fn parse_test_group(path: PathBuf) -> anyhow::Result<ParsedTestGroup> {
             continue;
         }
 
-        join_set.spawn(parse_test_sub_group(path.join(entry.path())));
+        join_set.spawn(parse_test_sub_group(
+            path.join(entry.path()),
+            filter_str.clone(),
+        ));
     }
 
     wait_for_task_to_finish_and_push_to_vec(&mut join_set, &mut sub_groups).await?;
@@ -82,7 +88,10 @@ async fn parse_test_group(path: PathBuf) -> anyhow::Result<ParsedTestGroup> {
     })
 }
 
-async fn parse_test_sub_group(path: PathBuf) -> anyhow::Result<ParsedTestSubGroup> {
+async fn parse_test_sub_group(
+    path: PathBuf,
+    filter_str: Option<String>,
+) -> anyhow::Result<ParsedTestSubGroup> {
     debug!("Reading in test subgroup {:?}...", path);
     let (mut tests, mut join_set, mut read_dirs) = parse_dir_init(&path).await?;
 
@@ -93,7 +102,12 @@ async fn parse_test_sub_group(path: PathBuf) -> anyhow::Result<ParsedTestSubGrou
             continue;
         }
 
-        join_set.spawn(read_parsed_test(path.join(entry.path())));
+        // Reject test if the filter string does not match.
+        if let Some(ref filter_str) = filter_str && !path.to_str().map_or(false, |path_str| path_str.contains(filter_str)) {
+            continue;
+        }
+
+        join_set.spawn(parse_test(path.join(entry.path())));
     }
 
     wait_for_task_to_finish_and_push_to_vec(&mut join_set, &mut tests).await?;
@@ -104,7 +118,7 @@ async fn parse_test_sub_group(path: PathBuf) -> anyhow::Result<ParsedTestSubGrou
     })
 }
 
-async fn read_parsed_test(path: PathBuf) -> anyhow::Result<Test> {
+async fn parse_test(path: PathBuf) -> anyhow::Result<Test> {
     trace!("Reading in {:?}...", path);
 
     let parsed_test_bytes = fs::read(&path).await?;
@@ -128,6 +142,9 @@ async fn wait_for_task_to_finish_and_push_to_vec<T: 'static>(
     Ok(())
 }
 
+/// Helper function to reduce code duplication.
+///
+/// Initializes variables that are common for each level of directory parsing.
 async fn parse_dir_init<T, U>(path: &Path) -> anyhow::Result<(Vec<T>, JoinSet<U>, ReadDirStream)> {
     let output = Vec::new();
     let join_set = JoinSet::new();

--- a/evm_test_runner/templates/filtered_test_results.md
+++ b/evm_test_runner/templates/filtered_test_results.md
@@ -1,0 +1,12 @@
+# Test Results {{ filter_str_template }}
+
+## Summary
+| passed | % |
+|--------|---|
+| {{ passed_info.num_passed }} / {{ passed_info.tot_tests }} | passed_info.perc_passed |
+
+
+{% for test in tests %}
+| name | status |
+| {{ test.name }} | test.status |
+{% endfor %}

--- a/evm_test_runner/templates/test_results_summary.md
+++ b/evm_test_runner/templates/test_results_summary.md
@@ -1,0 +1,21 @@
+# Test Results
+
+## Summary
+
+| group | passed | % |
+|-------|--------|---|
+{% for group in groups %}
+{{ group.name }} | {{ group.passed_info.num_passed }} / {{ group.passed_info.tot_tests }} | {{ group.passed_info.perc_passed }}
+{% endfor %}
+
+## Group Results
+
+{% for group in groups %}
+### {{ group.name }}
+{% for sub_group in group.sub_groups %}
+| sub-group | passed | % |
+|-----------|--------|---|
+{{ sub_group.name }} | (results/sub_groups/{{ sub_group.name }}) | {{ sub_group.passed_info.num_passed }} / {{ sub_group.passed_info.tot_tests }}  | {{ group.passed_info.perc_passed }} |
+
+{% endfor %}
+{% endfor %}

--- a/evm_test_runner/templates/test_results_summary.md
+++ b/evm_test_runner/templates/test_results_summary.md
@@ -5,7 +5,7 @@
 | group | passed | % |
 |-------|--------|---|
 {% for group in groups %}
-{{ group.name }} | {{ group.passed_info.num_passed }} / {{ group.passed_info.tot_tests }} | {{ group.passed_info.perc_passed }}
+| {{ group.name }} | {{ group.passed_info.num_passed }} / {{ group.passed_info.tot_tests }} | {{ group.passed_info.perc_passed }}
 {% endfor %}
 
 ## Group Results
@@ -15,7 +15,7 @@
 {% for sub_group in group.sub_groups %}
 | sub-group | passed | % |
 |-----------|--------|---|
-{{ sub_group.name }} | (results/sub_groups/{{ sub_group.name }}) | {{ sub_group.passed_info.num_passed }} / {{ sub_group.passed_info.tot_tests }}  | {{ group.passed_info.perc_passed }} |
+| {{ sub_group.name }} | (results/sub_groups/{{ sub_group.name }}) | {{ sub_group.passed_info.num_passed }} / {{ sub_group.passed_info.tot_tests }}  | {{ group.passed_info.perc_passed }} |
 
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
Implemented rendering test results for the runner.

There are two report types that are specifiable in the program args:

- Generate a summary markdown report for each test `group` with a row for the number of tests that passed for each `sub-group`.
- Run any tests that match a given (optional) string filter and output all tests that match. `group`s and `sub-groups` are flattened and all the individual tests that match are kept. Reports if the test passed and displays any failure information (if any). The output is rendered as markdown to `stdout`.

I think this is one of those cases where writing unit tests is not really worth it (just because we would have to write tests that match against generated markdown, which is probably going to be fairly unstable). So we'll work out the bugs once we are reading in data from the parser.

Also updated `IncorrectAccountFinalState` to show which trie hashes did not match in the case that at least one hash differs.