### PR TITLE
Make test runner `parsed_tests_path` argument optional

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,0 +1,1 @@
+pub const GENERATION_INPUTS_OUTPUT_DIR: &str = "generation_inputs";

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,1 +1,1 @@
-pub const GENERATION_INPUTS_OUTPUT_DIR: &str = "generation_inputs";
+pub const GENERATION_INPUTS_DEFAULT_OUTPUT_DIR: &str = "generation_inputs";

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod config;
 pub mod types;
 pub mod utils;

--- a/eth_test_parser/src/arg_parsing.rs
+++ b/eth_test_parser/src/arg_parsing.rs
@@ -1,8 +1,12 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about)]
 pub(crate) struct ProgArgs {
+    pub out_path: Option<PathBuf>,
+
     #[arg(short, long, default_value_t = false)]
     /// Allow deserializing without fetching git remote
     pub no_fetch: bool,

--- a/eth_test_parser/src/config.rs
+++ b/eth_test_parser/src/config.rs
@@ -1,4 +1,3 @@
 pub(crate) const ETH_TESTS_REPO_URL: &str = "https://github.com/ethereum/tests.git";
-pub(crate) const GENERATION_INPUTS_OUTPUT_DIR: &str = "generation_inputs";
 pub(crate) const ETH_TESTS_REPO_LOCAL_PATH: &str = "eth_tests";
 pub(crate) const TEST_GROUPS: [&str; 1] = ["GeneralStateTests"];

--- a/eth_test_parser/src/fs_scaffolding.rs
+++ b/eth_test_parser/src/fs_scaffolding.rs
@@ -6,8 +6,9 @@ use std::{
 };
 
 use anyhow::Result;
+use common::config::GENERATION_INPUTS_OUTPUT_DIR;
 
-use crate::config::{ETH_TESTS_REPO_LOCAL_PATH, GENERATION_INPUTS_OUTPUT_DIR, TEST_GROUPS};
+use crate::config::{ETH_TESTS_REPO_LOCAL_PATH, TEST_GROUPS};
 
 /// Generate an iterator over the outer test group folders.
 ///

--- a/eth_test_parser/src/main.rs
+++ b/eth_test_parser/src/main.rs
@@ -4,16 +4,14 @@ use std::{fs::File, path::PathBuf};
 use anyhow::Result;
 use arg_parsing::ProgArgs;
 use clap::Parser;
+use common::config::GENERATION_INPUTS_OUTPUT_DIR;
 use common::types::ParsedTest;
 use common::utils::init_env_logger;
 use fs_scaffolding::prepare_output_dir;
 use futures::future::join_all;
 use trie_builder::get_deserialized_test_bodies;
 
-use crate::{
-    config::{ETH_TESTS_REPO_LOCAL_PATH, GENERATION_INPUTS_OUTPUT_DIR},
-    eth_tests_fetching::clone_or_update_remote_tests,
-};
+use crate::{config::ETH_TESTS_REPO_LOCAL_PATH, eth_tests_fetching::clone_or_update_remote_tests};
 
 mod arg_parsing;
 mod config;

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -18,7 +18,7 @@ pub(crate) enum ReportType {
 #[clap(author, version, about)]
 pub(crate) struct ProgArgs {
     /// The path to the parsed tests directory.
-    pub(crate) parsed_tests_path: PathBuf,
+    pub(crate) parsed_tests_path: Option<PathBuf>,
 
     #[arg(short='r', long, value_enum, default_value_t=ReportType::Test)]
     /// The type of report to generate.

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -6,7 +6,7 @@ use common::utils::init_env_logger;
 use log::info;
 use plonky2_runner::run_plonky2_tests;
 use report_generation::output_test_report_for_terminal;
-use test_dir_reading::read_in_all_parsed_tests;
+use test_dir_reading::{get_default_parsed_tests_path, read_in_all_parsed_tests};
 
 use crate::report_generation::write_overall_status_report_summary_to_file;
 
@@ -24,6 +24,10 @@ async fn main() -> anyhow::Result<()> {
         report_type,
         parsed_tests_path,
     } = ProgArgs::parse();
+
+    let parsed_tests_path = parsed_tests_path
+        .map(Ok)
+        .unwrap_or_else(get_default_parsed_tests_path)?;
 
     let parsed_tests = read_in_all_parsed_tests(&parsed_tests_path, test_filter.clone()).await?;
     let test_res = run_plonky2_tests(parsed_tests);

--- a/evm_test_runner/src/test_dir_reading.rs
+++ b/evm_test_runner/src/test_dir_reading.rs
@@ -10,8 +10,8 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Context;
-use common::types::ParsedTest;
+use anyhow::{anyhow, Context};
+use common::{config::GENERATION_INPUTS_OUTPUT_DIR, types::ParsedTest};
 use log::{debug, info, trace};
 use tokio::{
     fs::{self, read_dir},
@@ -35,6 +35,23 @@ pub(crate) struct ParsedTestSubGroup {
 pub(crate) struct Test {
     pub(crate) name: String,
     pub(crate) info: ParsedTest,
+}
+
+pub(crate) fn get_default_parsed_tests_path() -> anyhow::Result<PathBuf> {
+    std::env::current_dir()?
+        .ancestors()
+        .map(|ancestor| {
+            let mut buf = ancestor.to_path_buf();
+            buf.push(GENERATION_INPUTS_OUTPUT_DIR);
+            buf
+        })
+        .find(|path| path.exists())
+        .ok_or_else(|| {
+            anyhow!(
+                "Unable to find {} in cwd ancestry.",
+                GENERATION_INPUTS_OUTPUT_DIR
+            )
+        })
 }
 
 /// Reads in all parsed tests from the given parsed test directory.

--- a/evm_test_runner/src/test_dir_reading.rs
+++ b/evm_test_runner/src/test_dir_reading.rs
@@ -11,7 +11,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context};
-use common::{config::GENERATION_INPUTS_OUTPUT_DIR, types::ParsedTest};
+use common::{config::GENERATION_INPUTS_DEFAULT_OUTPUT_DIR, types::ParsedTest};
 use log::{debug, info, trace};
 use tokio::{
     fs::{self, read_dir},
@@ -42,14 +42,14 @@ pub(crate) fn get_default_parsed_tests_path() -> anyhow::Result<PathBuf> {
         .ancestors()
         .map(|ancestor| {
             let mut buf = ancestor.to_path_buf();
-            buf.push(GENERATION_INPUTS_OUTPUT_DIR);
+            buf.push(GENERATION_INPUTS_DEFAULT_OUTPUT_DIR);
             buf
         })
         .find(|path| path.exists())
         .ok_or_else(|| {
             anyhow!(
-                "Unable to find {} in cwd ancestry.",
-                GENERATION_INPUTS_OUTPUT_DIR
+                "Unable to find {} in cwd ancestry. Have you run the parser binary?",
+                GENERATION_INPUTS_DEFAULT_OUTPUT_DIR
             )
         })
 }


### PR DESCRIPTION
Update the test runner to traverse up current working directory's ancestry until it finds `GENERATION_INPUTS_OUTPUT_DIR`. Otherwise, error out.