### PR TITLE
Parser Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -15,7 +15,7 @@ plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f2d
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 clap = {version = "4.0.19", features = ["derive"] }
 ethereum-types = "0.14.0"
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 keccak-hash = "0.10.0"
 log = "0.4.17"
 rlp = "0.5.2"

--- a/eth_test_parser/src/trie_builder.rs
+++ b/eth_test_parser/src/trie_builder.rs
@@ -37,21 +37,28 @@ pub(crate) struct AccountRlp {
 
 /// Generate an iterator containing the deserialized test bodies (`TestBody`)
 /// and their `DirEntry`s.
-pub(crate) fn get_deserialized_test_bodies() -> Result<impl Iterator<Item = (DirEntry, TestBody)>> {
-    Ok(get_test_files()?.flat_map(|entry| {
-        let buf = BufReader::new(File::open(entry.path())?);
-        let file_json: HashMap<String, TestBody> = serde_json::from_reader(buf)?;
-
-        // Each test JSON always contains a single outer key containing the test name.
-        // The test name is irrelevant for deserialization purposes, so we always drop
-        // it.
-        let test_body = file_json
-            .into_values()
-            .next()
-            .ok_or_else(|| anyhow!("Empty test found: {:?}", entry))?;
-
-        anyhow::Ok((entry, test_body))
+pub(crate) fn get_deserialized_test_bodies(
+) -> Result<impl Iterator<Item = Result<(DirEntry, TestBody), (String, String)>>> {
+    Ok(get_test_files()?.map(|entry| {
+        let test_body = get_deserialized_test_body(&entry)
+            .map_err(|err| (err.to_string(), entry.path().to_string_lossy().to_string()))?;
+        Ok((entry, test_body))
     }))
+}
+
+fn get_deserialized_test_body(entry: &DirEntry) -> Result<TestBody> {
+    let buf = BufReader::new(File::open(entry.path())?);
+    let file_json: HashMap<String, TestBody> = serde_json::from_reader(buf)?;
+
+    // Each test JSON always contains a single outer key containing the test name.
+    // The test name is irrelevant for deserialization purposes, so we always drop
+    // it.
+    let test_body = file_json
+        .into_values()
+        .next()
+        .ok_or_else(|| anyhow!("Empty test found: {:?}", entry))?;
+
+    anyhow::Ok(test_body)
 }
 
 impl Env {


### PR DESCRIPTION
Two fixes:
- `ByteString` was parsing hex strings into byte vecs using the ASCII values of each character in the string.
- `get_deserialized_test_bodies` was throwing away any errors that occurred during parsing.

There is one design change with this PR, which is if a test fails to parse, then we continue going but print out a warning. The reasoning behind deciding to not panic the parser is the upstream tests may change at any time independently of our program. There are going to always be tests that are going to fail to parse (eg. some tests are missing a `merge` field, which need to be whitelisted), and if these change independently of our codebase, then to me it makes more sense to warn but continue going since we can never be sure that all tests will parse correctly.