### PR TITLE
Temp hack for filling in the expected state trie hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,9 +1485,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plonky2"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf672134f7f79739b0511f5abcfd110add584f2658d70be0cfb39ef0957d0a1"
+checksum = "d2a3d3069fc716f2733c4bafeaf57c256e507f0a599fc206f41ef273568ca2b7"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=6f2d99c7bce0728aff0374cf6bddff6c08b409ba#6f2d99c7bce0728aff0374cf6bddff6c08b409ba"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=5aafbaad491b89805b649650131ab80ee8c79605#5aafbaad491b89805b649650131ab80ee8c79605"
 dependencies = [
  "anyhow",
  "blake2",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -11,5 +11,5 @@ edition = "2021"
 ethereum-types = "0.14.0"
 eth_trie_utils = "0.4.1"
 flexi_logger = { version = "0.25.1", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f2d99c7bce0728aff0374cf6bddff6c08b409ba" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
 serde = {version = "1.0.147", features = ["derive"] }

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = "0.4.1"
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f2d99c7bce0728aff0374cf6bddff6c08b409ba" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
 
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 clap = {version = "4.0.19", features = ["derive"] }

--- a/eth_test_parser/src/main.rs
+++ b/eth_test_parser/src/main.rs
@@ -46,8 +46,8 @@ async fn run(ProgArgs { no_fetch, out_path }: ProgArgs) -> anyhow::Result<()> {
     let generation_input_handles = get_deserialized_test_bodies()?.filter_map(|res| {
         match res {
             Ok((test_dir_entry, test_body)) => Some(tokio::task::spawn_blocking(move || {
-                // TODO: For now if there are multiple txns, we are just going to process the
-                // first one. Later we will switch to processing all txns in the text.
+                // TODO: For now if there are multiple txn variants, we're just going to pick
+                // the first one. Later we will switch to processing all txns in the test.
                 let state_trie_hash = test_body.post.merge[0].hash;
                 (
                     test_dir_entry,

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 plonky2 = { version = "0.1.3", features = ["timing"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f2d99c7bce0728aff0374cf6bddff6c08b409ba" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.11.1"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { version = "0.1.1", features = ["timing"] }
+plonky2 = { version = "0.1.3", features = ["timing"] }
 plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f2d99c7bce0728aff0374cf6bddff6c08b409ba" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }


### PR DESCRIPTION
Just to get things going, sets the expected state trie hash to the hash in the first entry in merge. This is fine for tests with one txn variant, but incorrect for ones with multiple. Will fix soon.