### PR TITLE
Now breaks tests with variants into multiple tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,7 @@ dependencies = [
 name = "common"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "eth_trie_utils",
  "ethereum-types",
  "flexi_logger",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { version = "1.0.66", features = ["backtrace"] }
 ethereum-types = "0.14.0"
 eth_trie_utils = "0.4.1"
 flexi_logger = { version = "0.25.1", features = ["async"] }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1,13 +1,68 @@
+use std::collections::HashMap;
+
 use ethereum_types::H256;
-use plonky2_evm::generation::GenerationInputs;
+use plonky2_evm::{
+    generation::{GenerationInputs, TrieInputs},
+    proof::BlockMetadata,
+};
 use serde::{Deserialize, Serialize};
 
 /// A parsed Ethereum test that is ready to be fed into `Plonky2`.
-
+///
+/// Note that for our runner we break any txn "variants" (see `indexes` under https://ethereum-tests.readthedocs.io/en/latest/test_types/gstate_tests.html#post-section) into separate sub-tests when running. This is because we don't want a single sub-test variant to cause the entire test to fail (we just want the variant to fail).
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ParsedTest {
-    pub plonky2_inputs: GenerationInputs,
+    pub test_variants: Vec<TestVariant>,
 
-    /// If the test specifies a final account trie state, this will be filled.
-    pub expected_final_account_states: Option<H256>,
+    /// State that is constant between tests.
+    pub const_plonky2_inputs: ConstGenerationInputs,
+}
+
+impl ParsedTest {
+    /// Construct the actual test variants for the test.
+    pub fn get_test_variants(self) -> Vec<TestVariantRunInfo> {
+        self.test_variants
+            .into_iter()
+            .map(|t_var| {
+                let gen_inputs = GenerationInputs {
+                    signed_txns: vec![t_var.txn_bytes],
+                    tries: self.const_plonky2_inputs.tries.clone(),
+                    contract_code: self.const_plonky2_inputs.contract_code.clone(),
+                    block_metadata: self.const_plonky2_inputs.block_metadata.clone(),
+                };
+
+                TestVariantRunInfo {
+                    gen_inputs,
+                    common: t_var.common,
+                }
+            })
+            .collect()
+    }
+}
+
+/// A single test that
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TestVariant {
+    /// The txn bytes for each txn in the test.
+    pub txn_bytes: Vec<u8>,
+    pub common: TestVariantCommon,
+}
+
+#[derive(Debug)]
+pub struct TestVariantRunInfo {
+    pub gen_inputs: GenerationInputs,
+    pub common: TestVariantCommon,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TestVariantCommon {
+    /// The root hash of the expected final state trie.
+    pub expected_final_account_state_root_hash: H256,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ConstGenerationInputs {
+    pub tries: TrieInputs,
+    pub contract_code: HashMap<H256, Vec<u8>>,
+    pub block_metadata: BlockMetadata,
 }

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -13,7 +13,7 @@ eth_trie_utils = "0.4.1"
 plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
 
 anyhow = { version = "1.0.66", features = ["backtrace"] }
-clap = {version = "4.0.19", features = ["derive"] }
+clap = {version = "4.1.8", features = ["derive"] }
 ethereum-types = "0.14.0"
 hex = { version = "0.4.3", features = ["serde"] }
 flexi_logger = { version = "0.25.1", features = ["async"] }

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -15,7 +15,7 @@ plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aaf
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.11.1"
 backtrace = "0.3.66"
-clap = {version = "4.0.19", features = ["derive"] }
+clap = {version = "4.1.8", features = ["derive"] }
 ethereum-types = "0.14.0"
 flexi_logger = { version = "0.25.1", features = ["async"] }
 indicatif = "0.17.1"

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -1,6 +1,66 @@
-use std::path::PathBuf;
+use std::{
+    ops::RangeInclusive,
+    path::PathBuf,
+    str::{FromStr, Split},
+};
 
+use anyhow::{anyhow, Context};
 use clap::{Parser, ValueEnum};
+
+#[derive(Clone, Debug)]
+pub(crate) enum VariantFilterType {
+    Single(usize),
+    Range(RangeInclusive<usize>),
+}
+
+impl FromStr for VariantFilterType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str_intern(s)
+            .with_context(|| {
+                format!(
+                    "Expected a single value or a range, but instead got \"{}\".",
+                    s
+                )
+            })
+            .map_err(|e| format!("{e:#}"))
+    }
+}
+
+impl VariantFilterType {
+    fn from_str_intern(s: &str) -> anyhow::Result<Self> {
+        // Did we get passed a single value?
+        if let Ok(v) = s.parse::<usize>() {
+            return Ok(Self::Single(v));
+        }
+
+        // Check if it's a range.
+        let mut range_vals = s.split("..=");
+
+        let start = Self::next_and_try_parse(&mut range_vals)?;
+        let end = Self::next_and_try_parse(&mut range_vals)?;
+
+        if range_vals.count() > 0 {
+            return Err(anyhow!(
+                "Parsed a range but there were unexpected characters afterwards!"
+            ));
+        }
+
+        Ok(Self::Range(start..=end))
+    }
+
+    fn next_and_try_parse(range_vals: &mut Split<&str>) -> anyhow::Result<usize> {
+        let unparsed_val = range_vals
+            .next()
+            .with_context(|| "Parsing a value as a `RangeInclusive`")?;
+        let res = unparsed_val
+            .parse()
+            .with_context(|| format!("Parsing the range val \"{unparsed_val}\" into a usize"))?;
+
+        Ok(res)
+    }
+}
 
 #[derive(Clone, Debug, ValueEnum)]
 pub(crate) enum ReportType {
@@ -23,6 +83,11 @@ pub(crate) struct ProgArgs {
     #[arg(short='r', long, value_enum, default_value_t=ReportType::Test)]
     /// The type of report to generate.
     pub(crate) report_type: ReportType,
+
+    #[arg(short, long)]
+    /// Only run test variants that match this index (either a single value or a
+    /// range).
+    pub(crate) variant_filter: Option<VariantFilterType>,
 
     #[arg(short = 'f', long)]
     /// An optional filter to only run tests that are a subset of the given

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -1,66 +1,7 @@
-use std::{
-    ops::RangeInclusive,
-    path::PathBuf,
-    str::{FromStr, Split},
-};
+use std::path::PathBuf;
 
-use anyhow::{anyhow, Context};
 use clap::{Parser, ValueEnum};
-
-#[derive(Clone, Debug)]
-pub(crate) enum VariantFilterType {
-    Single(usize),
-    Range(RangeInclusive<usize>),
-}
-
-impl FromStr for VariantFilterType {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_str_intern(s)
-            .with_context(|| {
-                format!(
-                    "Expected a single value or a range, but instead got \"{}\".",
-                    s
-                )
-            })
-            .map_err(|e| format!("{e:#}"))
-    }
-}
-
-impl VariantFilterType {
-    fn from_str_intern(s: &str) -> anyhow::Result<Self> {
-        // Did we get passed a single value?
-        if let Ok(v) = s.parse::<usize>() {
-            return Ok(Self::Single(v));
-        }
-
-        // Check if it's a range.
-        let mut range_vals = s.split("..=");
-
-        let start = Self::next_and_try_parse(&mut range_vals)?;
-        let end = Self::next_and_try_parse(&mut range_vals)?;
-
-        if range_vals.count() > 0 {
-            return Err(anyhow!(
-                "Parsed a range but there were unexpected characters afterwards!"
-            ));
-        }
-
-        Ok(Self::Range(start..=end))
-    }
-
-    fn next_and_try_parse(range_vals: &mut Split<&str>) -> anyhow::Result<usize> {
-        let unparsed_val = range_vals
-            .next()
-            .with_context(|| "Parsing a value as a `RangeInclusive`")?;
-        let res = unparsed_val
-            .parse()
-            .with_context(|| format!("Parsing the range val \"{unparsed_val}\" into a usize"))?;
-
-        Ok(res)
-    }
-}
+use common::types::VariantFilterType;
 
 #[derive(Clone, Debug, ValueEnum)]
 pub(crate) enum ReportType {
@@ -87,6 +28,8 @@ pub(crate) struct ProgArgs {
     #[arg(short, long)]
     /// Only run test variants that match this index (either a single value or a
     /// range).
+    ///
+    /// Eg: `0`, `0..=5`
     pub(crate) variant_filter: Option<VariantFilterType>,
 
     #[arg(short = 'f', long)]

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> anyhow::Result<()> {
     let ProgArgs {
         test_filter,
         report_type,
+        variant_filter: _,
         parsed_tests_path,
     } = ProgArgs::parse();
 

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
     let ProgArgs {
         test_filter,
         report_type,
-        variant_filter: _,
+        variant_filter,
         parsed_tests_path,
     } = ProgArgs::parse();
 
@@ -30,7 +30,8 @@ async fn main() -> anyhow::Result<()> {
         .map(Ok)
         .unwrap_or_else(get_default_parsed_tests_path)?;
 
-    let parsed_tests = read_in_all_parsed_tests(&parsed_tests_path, test_filter.clone()).await?;
+    let parsed_tests =
+        read_in_all_parsed_tests(&parsed_tests_path, test_filter.clone(), variant_filter).await?;
     let test_res = run_plonky2_tests(parsed_tests);
 
     match report_type {


### PR DESCRIPTION
Now runs tests with "variants" as multiple tests.

Note that the parser still creates a single `*.cbor` output for a test. It's when this is read in by the runner that it runs the variants as separate tests.