### PR TITLE
Generate test expected state diffs using revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +164,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
@@ -207,6 +236,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -289,6 +321,8 @@ dependencies = [
  "ethereum-types",
  "flexi_logger",
  "plonky2_evm",
+ "revm",
+ "ruint",
  "serde",
 ]
 
@@ -304,6 +338,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "const-random"
@@ -326,6 +366,12 @@ dependencies = [
  "proc-macro-hack",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "coolor"
@@ -450,6 +496,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -515,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -529,12 +587,34 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -550,16 +630,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "enumn"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1940ea32e14d489b401074558be4567f35ca9507c4628b4b3fd6fe6eb2ca7b88"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "env_logger"
@@ -610,8 +732,10 @@ dependencies = [
  "keccak-hash 0.10.0",
  "log",
  "plonky2_evm",
+ "revm",
  "rlp",
  "rlp-derive",
+ "ruint",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -673,16 +797,31 @@ dependencies = [
  "askama",
  "clap",
  "common",
+ "console",
  "ethereum-types",
  "flexi_logger",
  "indicatif",
+ "keccak-hash 0.10.0",
  "log",
  "plonky2",
  "plonky2_evm",
+ "revm",
+ "ruint",
  "serde_cbor",
+ "similar",
  "termimad",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -859,6 +998,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,8 +1020,18 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "rayon",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
  "serde",
 ]
 
@@ -919,6 +1079,15 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "humansize"
@@ -1007,7 +1176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1090,6 +1259,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+ "sha3",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "keccak-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1305,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
@@ -1489,9 +1683,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2a3d3069fc716f2733c4bafeaf57c256e507f0a599fc206f41ef273568ca2b7"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "anyhow",
- "hashbrown",
+ "hashbrown 0.12.3",
  "itertools",
  "keccak-hash 0.8.0",
  "log",
@@ -1509,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "plonky2_evm"
 version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=5aafbaad491b89805b649650131ab80ee8c79605#5aafbaad491b89805b649650131ab80ee8c79605"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=f4e65feb65b74620f8c664ae82f8e68ee6f0370e#f4e65feb65b74620f8c664ae82f8e68ee6f0370e"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1522,6 +1716,7 @@ dependencies = [
  "keccak-hash 0.10.0",
  "log",
  "num",
+ "num-bigint",
  "once_cell",
  "pest",
  "pest_derive",
@@ -1746,6 +1941,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "revm"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284747ad0324ed0e805dcf8f412e2beccb7a547fbd84f0607865001b8719c515"
+dependencies = [
+ "auto_impl",
+ "revm-interpreter",
+ "revm-precompile",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1b86f1d21d1852b40ec8ac9b6d31ac8a7c000875155809d41ce68f6369dc56"
+dependencies = [
+ "derive_more",
+ "enumn",
+ "revm-primitives",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66837781605c6dcb7f07ad87604eeab3119dae9149d69d8839073dd6f188673d"
+dependencies = [
+ "k256",
+ "num",
+ "once_cell",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1",
+ "sha2",
+ "sha3",
+ "substrate-bn",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad165d3f69e4d14405d82c6625864ee48c162dcebdf170322e6dd80398226a9e"
+dependencies = [
+ "auto_impl",
+ "bytes",
+ "derive_more",
+ "enumn",
+ "fixed-hash 0.8.0",
+ "hashbrown 0.13.2",
+ "hex",
+ "hex-literal",
+ "rlp",
+ "ruint",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1767,6 +2044,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad3a104dc8c3867f653b0fec89c65e00b0ceb752718ad282177a7e0f33257ac"
+dependencies = [
+ "derive_more",
+ "primitive-types 0.12.1",
+ "rlp",
+ "ruint-macro",
+ "rustc_version",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62cc5760263ea229d367e7dff3c0cbf09e4797a125bd87059a6c095804f3b2d1"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +2075,15 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1809,6 +2116,43 @@ name = "scratch"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+dependencies = [
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -1862,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
+checksum = "85456ffac572dc8826334164f2fb6fb40a7c766aebe195a2a21ee69ee2885ecf"
 dependencies = [
  "base64",
  "chrono",
@@ -1878,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1966009f3c05f095697c537312f5415d1e3ed31ce0a56942bac4c771c5c335e"
+checksum = "7cbcd6104f8a4ab6af7f6be2a0da6be86b9de3c401f6e86bb856ab2af739232f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1897,6 +2241,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -1930,6 +2284,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,6 +2325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1965,6 +2341,19 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand",
+ "rustc-hex",
+]
 
 [[package]]
 name = "subtle"
@@ -2034,9 +2423,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
@@ -2052,9 +2441,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -2377,3 +2766,9 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,5 +12,7 @@ anyhow = { version = "1.0.66", features = ["backtrace"] }
 ethereum-types = "0.14.0"
 eth_trie_utils = "0.4.1"
 flexi_logger = { version = "0.25.1", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "f4e65feb65b74620f8c664ae82f8e68ee6f0370e" }
 serde = {version = "1.0.147", features = ["derive"] }
+revm = { version = "3.0.0", features = ["serde"] }
+ruint = { version = "1.7.0", features = ["primitive-types"] }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -1,1 +1,2 @@
 pub const GENERATION_INPUTS_DEFAULT_OUTPUT_DIR: &str = "generation_inputs";
+pub const MATIC_CHAIN_ID: u64 = 137;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
+pub mod revm;
 pub mod types;
 pub mod utils;

--- a/common/src/revm/cache_db.rs
+++ b/common/src/revm/cache_db.rs
@@ -1,0 +1,135 @@
+//! The [`CacheDb`](revm::db::CacheDB) struct isn't serializable, so we need to
+//! have our own representation of it. `From` is implemented on both sides to
+//! make it easy to convert between the two.
+
+use revm::{
+    db::{AccountState, CacheDB, DbAccount},
+    primitives::{AccountInfo, Bytecode, HashMap, Log, B160, B256, U256},
+    InMemoryDB,
+};
+use serde::{Deserialize, Serialize};
+
+/// Serializable version of [`AccountState`](revm::db::AccountState)
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum SerializableAccountState {
+    NotExisting,
+    Touched,
+    StorageCleared,
+    #[default]
+    None,
+}
+
+impl From<AccountState> for SerializableAccountState {
+    fn from(account_state: AccountState) -> Self {
+        match account_state {
+            AccountState::NotExisting => Self::NotExisting,
+            AccountState::Touched => Self::Touched,
+            AccountState::StorageCleared => Self::StorageCleared,
+            AccountState::None => Self::None,
+        }
+    }
+}
+
+impl From<SerializableAccountState> for AccountState {
+    fn from(account_state: SerializableAccountState) -> Self {
+        match account_state {
+            SerializableAccountState::NotExisting => Self::NotExisting,
+            SerializableAccountState::Touched => Self::Touched,
+            SerializableAccountState::StorageCleared => Self::StorageCleared,
+            SerializableAccountState::None => Self::None,
+        }
+    }
+}
+
+/// Serializable version of [`DbAccount`](revm::db::DbAccount)
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SerializableDbAccount {
+    pub info: AccountInfo,
+    pub account_state: SerializableAccountState,
+    pub storage: HashMap<U256, U256>,
+}
+
+impl From<DbAccount> for SerializableDbAccount {
+    fn from(
+        DbAccount {
+            info,
+            account_state,
+            storage,
+        }: DbAccount,
+    ) -> Self {
+        Self {
+            info,
+            account_state: account_state.into(),
+            storage,
+        }
+    }
+}
+
+impl From<SerializableDbAccount> for DbAccount {
+    fn from(
+        SerializableDbAccount {
+            info,
+            account_state,
+            storage,
+        }: SerializableDbAccount,
+    ) -> Self {
+        Self {
+            info,
+            account_state: account_state.into(),
+            storage,
+        }
+    }
+}
+
+/// Serializable version of [`InMemoryDB`](revm::db::InMemoryDB)
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SerializableInMemoryDb {
+    pub accounts: HashMap<B160, SerializableDbAccount>,
+    pub contracts: HashMap<B256, Bytecode>,
+    pub logs: Vec<Log>,
+    pub block_hashes: HashMap<U256, B256>,
+}
+
+impl From<InMemoryDB> for SerializableInMemoryDb {
+    fn from(
+        CacheDB {
+            accounts,
+            contracts,
+            logs,
+            block_hashes,
+            ..
+        }: InMemoryDB,
+    ) -> Self {
+        Self {
+            accounts: accounts
+                .into_iter()
+                .map(|(address, account)| (address, SerializableDbAccount::from(account)))
+                .collect(),
+            contracts,
+            logs,
+            block_hashes,
+        }
+    }
+}
+
+impl From<SerializableInMemoryDb> for InMemoryDB {
+    fn from(
+        SerializableInMemoryDb {
+            accounts,
+            contracts,
+            logs,
+            block_hashes,
+        }: SerializableInMemoryDb,
+    ) -> Self {
+        Self {
+            accounts: accounts
+                .into_iter()
+                .map(|(address, account)| (address, DbAccount::from(account)))
+                .collect(),
+            contracts,
+            logs,
+            block_hashes,
+            ..Default::default()
+        }
+    }
+}

--- a/common/src/revm/mod.rs
+++ b/common/src/revm/mod.rs
@@ -1,0 +1,40 @@
+//! Serializable wrapper types for an [`EVM`](revm::EVM) instance.
+//!
+//! Getting a fully constructed [`revm`](revm) environment requires the
+//! following steps:
+//!
+//! 1. Construct an [`EVM`](revm::EVM) instance.
+//! 2. Configure the instance's [`Env`](revm::primitives::Env). Note this
+//!    includes setting up the transaction we're testing at this step.
+//! 3. Construct a [`Db`](revm::db::Database). In our case, an
+//!    [`InMemoryDB`](revm::InMemoryDB).
+//! 4. Load the database with the accounts and their storage.
+
+use revm::{primitives::Env, InMemoryDB, EVM};
+use serde::{Deserialize, Serialize};
+
+use self::cache_db::SerializableInMemoryDb;
+
+pub mod cache_db;
+
+/// Serialized version of a hydrated evm instance.
+#[derive(Deserialize, Serialize, Debug)]
+pub struct SerializableEVMInstance {
+    pub env: Env,
+    pub db: SerializableInMemoryDb,
+}
+
+impl SerializableEVMInstance {
+    pub fn into_hydrated(self) -> EVM<InMemoryDB> {
+        EVM {
+            db: Some(self.db.into()),
+            env: self.env,
+        }
+    }
+}
+
+impl From<SerializableEVMInstance> for EVM<InMemoryDB> {
+    fn from(value: SerializableEVMInstance) -> Self {
+        value.into_hydrated()
+    }
+}

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = "0.4.1"
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "f4e65feb65b74620f8c664ae82f8e68ee6f0370e" }
 
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 clap = {version = "4.1.8", features = ["derive"] }
@@ -28,3 +28,5 @@ serde_with = "2.0.1"
 serde_cbor = "0.11.2"
 tokio = { version = "1.21.2", features = ["full"] }
 futures = "0.3.25"
+revm = { version = "3.0.0", features = ["serde"] }
+ruint = { version = "1.7.0", features = ["primitive-types"] }

--- a/eth_test_parser/src/revm_builder/cache_db.rs
+++ b/eth_test_parser/src/revm_builder/cache_db.rs
@@ -1,0 +1,43 @@
+//! Logic for dealing with converting a
+//! [`TestBody`](crate::deserialize::TestBody) into
+//! `revm`'s [`InMemoryDB`](revm::InMemoryDB)
+
+use anyhow::Result;
+use common::revm::cache_db::SerializableInMemoryDb;
+use revm::{
+    primitives::{AccountInfo, Bytecode},
+    InMemoryDB,
+};
+
+use crate::deserialize::TestBody;
+
+impl TestBody {
+    pub(crate) fn as_revm_cache_db(&self) -> Result<SerializableInMemoryDb> {
+        let mut db = InMemoryDB::default();
+
+        for (address, account) in &self.pre {
+            let address = address.to_fixed_bytes().into();
+            let account_info = AccountInfo::new(
+                account.balance.into(),
+                account.nonce,
+                Bytecode::new_raw(account.code.0.clone().into()).to_checked(),
+            );
+
+            db.insert_account_info(address, account_info);
+
+            for (key, value) in account.storage.iter() {
+                db.insert_account_storage(address, (*key).into(), (*value).into())?;
+            }
+        }
+
+        Ok(db.into())
+    }
+}
+
+impl TryFrom<&TestBody> for SerializableInMemoryDb {
+    type Error = anyhow::Error;
+
+    fn try_from(body: &TestBody) -> Result<Self> {
+        body.as_revm_cache_db()
+    }
+}

--- a/eth_test_parser/src/revm_builder/env.rs
+++ b/eth_test_parser/src/revm_builder/env.rs
@@ -1,0 +1,130 @@
+//! Convert a `TestBody` into a `Vec` of [`Env`](revm::primitives::Env).
+use anyhow::Result;
+use common::config::MATIC_CHAIN_ID;
+use revm::primitives::{BlockEnv, Bytes, CfgEnv, Env, TransactTo, TxEnv};
+
+use crate::deserialize::TestBody;
+
+struct TxSharedData {
+    data: Vec<Bytes>,
+    gas_limit: Vec<u64>,
+    value: Vec<ruint::aliases::U256>,
+}
+
+impl TestBody {
+    fn try_as_tx_shared_data(&self) -> Result<TxSharedData> {
+        let data = self
+            .transaction
+            .data
+            .iter()
+            .map(|byte_string| byte_string.0.clone().into())
+            .collect();
+
+        let gas_limit = self.transaction.gas_limit.to_vec();
+
+        let value = self
+            .transaction
+            .value
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let u256: ethereum_types::U256 = v.try_into().map_err(|_| {
+                    anyhow::Error::msg("Overflow").context(format!(
+                        "Unable to convert transaction.value[{i}] to U256. Got {v}"
+                    ))
+                })?;
+                Ok(u256.into())
+            })
+            .collect::<Result<Vec<revm::primitives::U256>>>()?;
+
+        Ok(TxSharedData {
+            data,
+            gas_limit,
+            value,
+        })
+    }
+
+    pub(crate) fn as_revm_env(&self) -> Result<Vec<Env>> {
+        let cfg = CfgEnv {
+            chain_id: MATIC_CHAIN_ID.try_into()?,
+            ..Default::default()
+        };
+
+        let block = BlockEnv {
+            number: self.env.current_number.into(),
+            coinbase: self.env.current_coinbase.to_fixed_bytes().into(),
+            timestamp: self.env.current_timestamp.into(),
+            difficulty: self.env.current_difficulty.into(),
+            prevrandao: Some(
+                <ethereum_types::U256 as std::convert::Into<revm::primitives::U256>>::into(
+                    self.env.current_difficulty,
+                )
+                .to_be_bytes()
+                .into(),
+            ),
+            basefee: self.env.current_base_fee.into(),
+            gas_limit: self.env.current_gas_limit.into(),
+        };
+
+        let access_list: Vec<(revm::primitives::B160, Vec<ruint::aliases::U256>)> = self
+            .pre
+            .iter()
+            .map(|(address, account)| {
+                let address = address.to_fixed_bytes().into();
+                let slots = account.storage.keys().map(|key| (*key).into()).collect();
+                (address, slots)
+            })
+            .collect();
+
+        let gas_price = self
+            .transaction
+            .gas_price
+            .map(|p| p.into())
+            .unwrap_or_default();
+
+        let transact_to = match self.transaction.to {
+            Some(to) => TransactTo::Call(to.to_fixed_bytes().into()),
+            None => TransactTo::Call(Default::default()),
+        };
+
+        let tx_shared_data: TxSharedData = self.try_into()?;
+
+        Ok(self
+            .post
+            .merge
+            .iter()
+            .map(|m| Env {
+                cfg: cfg.clone(),
+                block: block.clone(),
+                tx: TxEnv {
+                    caller: self.transaction.sender.to_fixed_bytes().into(),
+                    gas_limit: tx_shared_data.gas_limit[m.indexes.gas],
+                    gas_price,
+                    gas_priority_fee: None,
+                    transact_to: transact_to.clone(),
+                    value: tx_shared_data.value[m.indexes.value],
+                    data: tx_shared_data.data[m.indexes.data].clone(),
+                    chain_id: Some(MATIC_CHAIN_ID),
+                    nonce: self.transaction.nonce.try_into().ok(),
+                    access_list: access_list.clone(),
+                },
+            })
+            .collect())
+    }
+}
+
+impl TryFrom<&TestBody> for TxSharedData {
+    type Error = anyhow::Error;
+
+    fn try_from(body: &TestBody) -> Result<Self> {
+        body.try_as_tx_shared_data()
+    }
+}
+
+impl TryFrom<&TestBody> for Vec<Env> {
+    type Error = anyhow::Error;
+
+    fn try_from(body: &TestBody) -> Result<Self> {
+        body.as_revm_env()
+    }
+}

--- a/eth_test_parser/src/revm_builder/mod.rs
+++ b/eth_test_parser/src/revm_builder/mod.rs
@@ -1,0 +1,43 @@
+//! Utilities constructing an in-memory [`revm`](revm) environment from a
+//! [`TestBody`](crate::deserialize::TestBody).
+//!
+//! Getting a fully constructed [`revm`](revm) environment requires the
+//! following steps:
+//!
+//! 1. Construct an [`EVM`](revm::EVM) instance.
+//! 2. Configure the instance's [`Env`](revm::primitives::Env). Note this
+//!    includes setting up the transaction we're testing at this step.
+//! 3. Construct a [`Db`](revm::db::Database). In our case, an
+//!    [`InMemoryDB`](revm::InMemoryDB).
+//! 4. Load the database with the accounts and their storage.
+
+use anyhow::Result;
+use common::revm::SerializableEVMInstance;
+
+use crate::deserialize::TestBody;
+
+mod cache_db;
+mod env;
+
+impl TestBody {
+    pub(crate) fn as_serializable_evm_instances(&self) -> Result<Vec<SerializableEVMInstance>> {
+        let envs = self.as_revm_env()?;
+        let db = self.as_revm_cache_db()?;
+
+        Ok(envs
+            .into_iter()
+            .map(|env| SerializableEVMInstance {
+                env,
+                db: db.clone(),
+            })
+            .collect())
+    }
+}
+
+impl TryFrom<TestBody> for Vec<SerializableEVMInstance> {
+    type Error = anyhow::Error;
+
+    fn try_from(body: TestBody) -> Result<Self> {
+        body.as_serializable_evm_instances()
+    }
+}

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 plonky2 = { version = "0.1.3", features = ["timing"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "5aafbaad491b89805b649650131ab80ee8c79605" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "f4e65feb65b74620f8c664ae82f8e68ee6f0370e" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.11.1"
@@ -23,3 +23,8 @@ serde_cbor = "0.11.2"
 termimad = "0.20.3"
 tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-stream = {version  = "0.1.11", features = ["fs"] }
+revm = "3.0.0"
+similar = { version = "2.2.1", features = ["inline"] }
+ruint = { version = "1.7.0", features = ["primitive-types"] }
+keccak-hash = "0.10.0"
+console = "0.15.5"

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -13,6 +13,7 @@ use crate::report_generation::write_overall_status_report_summary_to_file;
 mod arg_parsing;
 mod plonky2_runner;
 mod report_generation;
+mod state_diff;
 mod test_dir_reading;
 
 #[tokio::main()]

--- a/evm_test_runner/src/state_diff.rs
+++ b/evm_test_runner/src/state_diff.rs
@@ -1,0 +1,152 @@
+use std::{collections::HashMap, fmt::Display};
+
+use console::{style, Style};
+use ethereum_types::{Address, H160, H256, U256};
+use keccak_hash::keccak;
+use plonky2_evm::generation::outputs::{AccountOutput, AddressOrStateKey};
+use revm::primitives::{Account, B160};
+use similar::{ChangeTag, TextDiff};
+
+#[derive(Debug, Clone)]
+pub(crate) struct StateDiff {
+    revm_state: HashMap<Address, AccountCompare>,
+    plonky2_state: HashMap<Address, AccountCompare>,
+}
+
+#[derive(Eq, PartialEq, PartialOrd, Ord, Hash, Debug, Clone)]
+/// Normalized representation of an account.
+struct AccountCompare {
+    balance: U256,
+    nonce: u64,
+    storage: Vec<(U256, U256)>,
+}
+
+impl StateDiff {
+    /// Construct a new [`StateDiff`](crate::state_diff::StateDiff).
+    ///
+    /// We normalize both the revm and plonky2 states into `AccountCompare` to
+    /// make them comparable.
+    pub(crate) fn new(
+        revm_state: revm::primitives::HashMap<B160, Account>,
+        plonky2_state: HashMap<AddressOrStateKey, AccountOutput>,
+    ) -> Self {
+        // Store a lookup table from keccak hashes to addresses in the event
+        // that plonky2 is missing an address from its output.
+        let keccak_address_lookup: HashMap<H256, Address> = revm_state
+            .keys()
+            .map(|k| (keccak(k.to_fixed_bytes()), H160::from(k.to_fixed_bytes())))
+            .collect();
+
+        let revm_state = revm_state
+            .into_iter()
+            .map(|(k, v)| {
+                let mut storage = v
+                    .storage
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.present_value.into()))
+                    .collect::<Vec<(U256, U256)>>();
+                storage.sort_by(|a, b| b.0.cmp(&a.0));
+
+                (
+                    k.to_fixed_bytes().into(),
+                    AccountCompare {
+                        balance: v.info.balance.into(),
+                        nonce: v.info.nonce,
+                        storage,
+                    },
+                )
+            })
+            .collect();
+
+        let plonky2_state = plonky2_state
+            .into_iter()
+            .map(|(k, v)| {
+                let address = match k {
+                    AddressOrStateKey::Address(a) => a,
+                    // If the address is missing from the plonky2 output, we can look it up in the
+                    // keccak table.
+                    AddressOrStateKey::StateKey(k) => keccak_address_lookup[&k],
+                };
+
+                let mut storage = v
+                    .storage
+                    .into_iter()
+                    .map(|(k, v)| (k, v))
+                    .collect::<Vec<_>>();
+                storage.sort_by(|a, b| b.0.cmp(&a.0));
+
+                (
+                    address,
+                    AccountCompare {
+                        balance: v.balance,
+                        nonce: v.nonce,
+                        storage,
+                    },
+                )
+            })
+            .collect();
+
+        Self {
+            revm_state,
+            plonky2_state,
+        }
+    }
+}
+
+struct Line(Option<usize>);
+
+impl Display for Line {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.0 {
+            None => write!(f, "    "),
+            Some(idx) => write!(f, "{:<4}", idx + 1),
+        }
+    }
+}
+
+impl Display for StateDiff {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut fst = self.revm_state.iter().collect::<Vec<_>>();
+        fst.sort_by(|a, b| b.0.cmp(a.0));
+        let mut snd = self.plonky2_state.iter().collect::<Vec<_>>();
+        snd.sort_by(|a, b| b.0.cmp(a.0));
+
+        let text1 = format!("{:#?}", fst);
+        let text2 = format!("{:#?}", snd);
+        let diff = TextDiff::from_lines(text1.as_str(), text2.as_str());
+
+        for (idx, group) in diff.grouped_ops(10).iter().enumerate() {
+            if idx > 0 {
+                writeln!(f, "{:-^1$}", "-", 80)?;
+            }
+            for op in group {
+                for change in diff.iter_inline_changes(op) {
+                    let (sign, s) = match change.tag() {
+                        ChangeTag::Delete => ("-", Style::new().red()),
+                        ChangeTag::Insert => ("+", Style::new().green()),
+                        ChangeTag::Equal => (" ", Style::new().dim()),
+                    };
+                    write!(
+                        f,
+                        "{}{} |{}",
+                        style(Line(change.old_index())).dim(),
+                        style(Line(change.new_index())).dim(),
+                        s.apply_to(sign).bold(),
+                    )?;
+                    for (emphasized, value) in change.iter_strings_lossy() {
+                        if emphasized {
+                            write!(f, "{}", s.apply_to(value).underlined().on_black())?;
+                        } else {
+                            write!(f, "{}", s.apply_to(value))?;
+                        }
+                    }
+                    if change.missing_newline() {
+                        writeln!(f)?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/evm_test_runner/src/test_dir_reading.rs
+++ b/evm_test_runner/src/test_dir_reading.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, Context};
 use common::{
     config::GENERATION_INPUTS_DEFAULT_OUTPUT_DIR,
-    types::{ParsedTest, TestVariantRunInfo, VariantFilterType},
+    types::{ParsedTestManifest, TestVariantRunInfo, VariantFilterType},
 };
 use log::{info, trace};
 use tokio::{
@@ -150,10 +150,10 @@ async fn parse_test(
     trace!("Reading in {:?}...", path);
 
     let parsed_test_bytes = fs::read(&path).await?;
-    let parsed_test: ParsedTest = serde_cbor::from_slice(&parsed_test_bytes)
+    let parsed_test: ParsedTestManifest = serde_cbor::from_slice(&parsed_test_bytes)
         .unwrap_or_else(|_| panic!("Unable to parse the test {:?} (bad format)", path));
 
-    let test_variants = parsed_test.get_test_variants_with_variant_filter(variant_filter);
+    let test_variants = parsed_test.into_filtered_variants(variant_filter);
 
     let root_test_name = get_file_stem(&path)?;
     let t_name_f: Box<dyn Fn(usize) -> String> = match test_variants.len() {


### PR DESCRIPTION
## Summary
This PR enables showing a human-readable state diff between the state associated with `plonky2`'s proof generation output and a simulated exepected evm state, courtesy of [`revm`](https://github.com/bluealloy/revm).

<img width="1045" alt="image" src="https://user-images.githubusercontent.com/845717/227072815-fa134e01-7ce2-44da-9a95-49c5a89069d6.png">

## How it works

1. An in-memory instance of `revm`'s `EVM` is generated in the `eth_test_parser` crate using the test JSON from which we are generating `plonky2` test inputs. 
2. That instance is then serialized and written to disk alongside its associated `plonky2` test input.
3. In context of an individual test run, the test context now has access to the deserialized `EVM` instance.
4. If a test fails, that deserialized `EVM` instance is then materialized into a fully-hydrated (i.e., ready to execute) in-memory EVM client, and then executed.
5. Both the resulting `plonky2` state and the resulting `EVM` state are passed into a `StateDiff` struct, which takes care of transforming both output formats into a unified format that is comparable.
6. The `StateDiff` is then written to the terminal, using its `std::fmt::Display` implementation.