### PR TITLE
Fix access list

### DIFF
--- a/eth_test_parser/src/revm_builder/env.rs
+++ b/eth_test_parser/src/revm_builder/env.rs
@@ -66,7 +66,6 @@ impl TestBody {
             gas_limit: self.env.current_gas_limit.into(),
         };
 
-
         let gas_price = self
             .transaction
             .gas_price

--- a/eth_test_parser/src/revm_builder/env.rs
+++ b/eth_test_parser/src/revm_builder/env.rs
@@ -96,7 +96,8 @@ impl TestBody {
                     data: tx_shared_data.data[m.indexes.data].clone(),
                     chain_id: Some(MATIC_CHAIN_ID),
                     nonce: self.transaction.nonce.try_into().ok(),
-                    access_list: vec![], // TODO: Add `access_list` to `Transaction` and use it here.
+                    // TODO: Add `access_list` to `Transaction` and use it here.
+                    access_list: vec![],
                 },
             })
             .collect())

--- a/eth_test_parser/src/revm_builder/env.rs
+++ b/eth_test_parser/src/revm_builder/env.rs
@@ -66,15 +66,6 @@ impl TestBody {
             gas_limit: self.env.current_gas_limit.into(),
         };
 
-        let access_list: Vec<(revm::primitives::B160, Vec<ruint::aliases::U256>)> = self
-            .pre
-            .iter()
-            .map(|(address, account)| {
-                let address = address.to_fixed_bytes().into();
-                let slots = account.storage.keys().map(|key| (*key).into()).collect();
-                (address, slots)
-            })
-            .collect();
 
         let gas_price = self
             .transaction
@@ -106,7 +97,7 @@ impl TestBody {
                     data: tx_shared_data.data[m.indexes.data].clone(),
                     chain_id: Some(MATIC_CHAIN_ID),
                     nonce: self.transaction.nonce.try_into().ok(),
-                    access_list: access_list.clone(),
+                    access_list: vec![],
                 },
             })
             .collect())

--- a/eth_test_parser/src/revm_builder/env.rs
+++ b/eth_test_parser/src/revm_builder/env.rs
@@ -96,7 +96,7 @@ impl TestBody {
                     data: tx_shared_data.data[m.indexes.data].clone(),
                     chain_id: Some(MATIC_CHAIN_ID),
                     nonce: self.transaction.nonce.try_into().ok(),
-                    access_list: vec![],
+                    access_list: vec![], // TODO: Add `access_list` to `Transaction` and use it here.
                 },
             })
             .collect())


### PR DESCRIPTION
The current code adds all the pre-accounts to the env's access list. Therefore, each transaction is charged an extra 2400 gas per pre-account (more if there are storage keys).
Fixed by just using an empty access list, but I'm not sure if there are tests with non-empty access list in the env.