### PR TITLE
Hash revm storage key for state diff

### DIFF
--- a/evm_test_runner/src/state_diff.rs
+++ b/evm_test_runner/src/state_diff.rs
@@ -43,7 +43,7 @@ impl StateDiff {
                 let mut storage = v
                     .storage
                     .into_iter()
-                    .map(|(k, v)| (k.into(), v.present_value.into()))
+                    .map(|(k, v)| ((keccak(&k.to_be_bytes::<32>()).0).into(), v.present_value.into()))
                     .collect::<Vec<(U256, U256)>>();
                 storage.sort_by(|a, b| b.0.cmp(&a.0));
 

--- a/evm_test_runner/src/state_diff.rs
+++ b/evm_test_runner/src/state_diff.rs
@@ -43,7 +43,7 @@ impl StateDiff {
                 let mut storage = v
                     .storage
                     .into_iter()
-                    .map(|(k, v)| ((keccak(&k.to_be_bytes::<32>()).0).into(), v.present_value.into()))
+                    .map(|(k, v)| ((keccak(k.to_be_bytes::<32>()).0).into(), v.present_value.into()))
                     .collect::<Vec<(U256, U256)>>();
                 storage.sort_by(|a, b| b.0.cmp(&a.0));
 


### PR DESCRIPTION
The revm storage uses raw keys, while our storage uses hashed keys. For example, in this diff
<img width="889" alt="image" src="https://user-images.githubusercontent.com/22958988/228740780-194f3649-23c5-499d-9ae7-f887c1ff7de2.png">
the storage keys are actually the same since `keccak(1.to_bytes(32, 'big')) = 80084422859880547211683076133703299733277748156566366325829078699459944778998`.

This PR fixes this by hashing the revm storage keys for the state diff.
