### PR TITLE
Passing state tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 eth_tests
 generation_inputs
 reports
+test_pass_state

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -839,6 +839,7 @@ dependencies = [
  "ethereum-types",
  "flexi_logger",
  "futures",
+ "humantime",
  "indicatif",
  "keccak-hash 0.10.0",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf33c2a618cbe41ee43ae6e9f2e48368cd9f9db2896f10167d8d762679f639"
+dependencies = [
+ "nix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,8 +835,10 @@ dependencies = [
  "common",
  "console",
  "csv",
+ "ctrlc",
  "ethereum-types",
  "flexi_logger",
+ "futures",
  "indicatif",
  "keccak-hash 0.10.0",
  "log",
@@ -1443,6 +1455,18 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,14 +254,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -515,6 +518,27 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -796,9 +820,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "askama",
+ "chrono",
  "clap",
  "common",
  "console",
+ "csv",
  "ethereum-types",
  "flexi_logger",
  "indicatif",
@@ -808,6 +834,7 @@ dependencies = [
  "plonky2_evm",
  "revm",
  "ruint",
+ "serde",
  "serde_cbor",
  "similar",
  "termimad",
@@ -983,7 +1010,7 @@ checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1414,7 +1441,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
 
@@ -2219,7 +2246,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -2436,6 +2463,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
@@ -2598,6 +2636,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -14,11 +14,14 @@ plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "b667
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.11.1"
+chrono = { version = "0.4.24", features = ["serde"] }
 clap = {version = "4.1.8", features = ["derive"] }
+csv = "1.2.1"
 ethereum-types = "0.14.0"
 flexi_logger = { version = "0.25.1", features = ["async"] }
 indicatif = "0.17.1"
 log = "0.4.17"
+serde = "1.0.147"
 serde_cbor = "0.11.2"
 termimad = "0.20.3"
 tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread"] }

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.17"
 serde = "1.0.147"
 serde_cbor = "0.11.2"
 termimad = "0.20.3"
-tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread", "sync"] }
+tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread"] }
 tokio-stream = {version  = "0.1.11", features = ["fs"] }
 revm = "3.0.0"
 similar = { version = "2.2.1", features = ["inline"] }

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -17,14 +17,16 @@ askama = "0.11.1"
 chrono = { version = "0.4.24", features = ["serde"] }
 clap = {version = "4.1.8", features = ["derive"] }
 csv = "1.2.1"
+ctrlc = "3.2.5"
 ethereum-types = "0.14.0"
 flexi_logger = { version = "0.25.1", features = ["async"] }
+futures = "0.3"
 indicatif = "0.17.1"
 log = "0.4.17"
 serde = "1.0.147"
 serde_cbor = "0.11.2"
 termimad = "0.20.3"
-tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = {version = "1.21.2", features = ["fs", "macros", "rt-multi-thread", "sync"] }
 tokio-stream = {version  = "0.1.11", features = ["fs"] }
 revm = "3.0.0"
 similar = { version = "2.2.1", features = ["inline"] }

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -21,6 +21,7 @@ ctrlc = "3.2.5"
 ethereum-types = "0.14.0"
 flexi_logger = { version = "0.25.1", features = ["async"] }
 futures = "0.3"
+humantime = "2.1.0"
 indicatif = "0.17.1"
 log = "0.4.17"
 serde = "1.0.147"

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -37,6 +37,10 @@ pub(crate) struct ProgArgs {
     #[arg(short = 'f', long)]
     pub(crate) test_filter: Option<String>,
 
+    /// Do not run tests that have already passed in the past.
+    #[arg(short = 'p', long)]
+    pub(crate) skip_passed: bool,
+
     /// Mark a test as timed out if it takes longer than this amount of time.
     #[arg(short = 't', long)]
     pub(crate) test_timeout: Option<humantime::Duration>,

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -43,4 +43,10 @@ pub(crate) struct ProgArgs {
     /// stdout/stderr.
     #[arg(short, long, default_value_t = false)]
     pub(crate) simple_progress_indicator: bool,
+
+    /// Add/remove the persistent test pass state from the upstream parsed
+    /// tests. If a new test exists upstream, we add an entry to the persistent
+    /// state. If it's removed, we purge it from our persistent state.
+    #[arg(short = 'u', long, default_value_t = false)]
+    pub(crate) update_persistent_state_from_upstream: bool,
 }

--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -21,21 +21,25 @@ pub(crate) struct ProgArgs {
     /// The path to the parsed tests directory.
     pub(crate) parsed_tests_path: Option<PathBuf>,
 
-    #[arg(short='r', long, value_enum, default_value_t=ReportType::Test)]
     /// The type of report to generate.
+    #[arg(short='r', long, value_enum, default_value_t=ReportType::Test)]
     pub(crate) report_type: ReportType,
 
-    #[arg(short, long)]
     /// Only run test variants that match this index (either a single value or a
     /// range).
     ///
     /// Eg: `0`, `0..=5`
+    #[arg(short, long)]
     pub(crate) variant_filter: Option<VariantFilterType>,
 
-    #[arg(short = 'f', long)]
     /// An optional filter to only run tests that are a subset of the given
     /// test path.
+    #[arg(short = 'f', long)]
     pub(crate) test_filter: Option<String>,
+
+    /// Mark a test as timed out if it takes longer than this amount of time.
+    #[arg(short = 't', long)]
+    pub(crate) test_timeout: Option<humantime::Duration>,
 
     /// Use a simple progress indicator that relies on `println!`s instead of an
     /// actual progress bar to display the current test status. In some

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -4,6 +4,7 @@ use arg_parsing::{ProgArgs, ReportType};
 use clap::Parser;
 use common::utils::init_env_logger;
 use log::info;
+use persistent_run_state::load_existing_pass_state_from_disk_if_exists_or_create;
 use plonky2_runner::run_plonky2_tests;
 use report_generation::output_test_report_for_terminal;
 use test_dir_reading::{get_default_parsed_tests_path, read_in_all_parsed_tests};
@@ -29,13 +30,19 @@ async fn main() -> anyhow::Result<()> {
         simple_progress_indicator,
     } = ProgArgs::parse();
 
+    let mut persistent_test_state = load_existing_pass_state_from_disk_if_exists_or_create();
+
     let parsed_tests_path = parsed_tests_path
         .map(Ok)
         .unwrap_or_else(get_default_parsed_tests_path)?;
 
     let parsed_tests =
         read_in_all_parsed_tests(&parsed_tests_path, test_filter.clone(), variant_filter).await?;
-    let test_res = run_plonky2_tests(parsed_tests, simple_progress_indicator);
+    let test_res = run_plonky2_tests(
+        parsed_tests,
+        simple_progress_indicator,
+        &mut persistent_test_state,
+    );
 
     match report_type {
         ReportType::Test => {

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -11,6 +11,7 @@ use test_dir_reading::{get_default_parsed_tests_path, read_in_all_parsed_tests};
 use crate::report_generation::write_overall_status_report_summary_to_file;
 
 mod arg_parsing;
+mod persistent_run_state;
 mod plonky2_runner;
 mod report_generation;
 mod state_diff;

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -1,15 +1,15 @@
 #![feature(let_chains)]
 
+use std::sync::{atomic::AtomicBool, Arc};
+
 use arg_parsing::{ProgArgs, ReportType};
 use clap::Parser;
 use common::utils::init_env_logger;
-use futures::executor::block_on;
 use log::info;
 use persistent_run_state::load_existing_pass_state_from_disk_if_exists_or_create;
 use plonky2_runner::run_plonky2_tests;
 use report_generation::output_test_report_for_terminal;
 use test_dir_reading::{get_default_parsed_tests_path, read_in_all_parsed_tests};
-use tokio::sync::mpsc;
 
 use crate::report_generation::write_overall_status_report_summary_to_file;
 
@@ -20,12 +20,11 @@ mod report_generation;
 mod state_diff;
 mod test_dir_reading;
 
-pub(crate) type ProcessAbortedRecv = mpsc::Receiver<()>;
+pub(crate) type ProcessAbortedRecv = Arc<AtomicBool>;
 
 #[tokio::main()]
 async fn main() -> anyhow::Result<()> {
     init_env_logger();
-
     let abort_recv = init_ctrl_c_handler();
 
     let ProgArgs {
@@ -46,11 +45,19 @@ async fn main() -> anyhow::Result<()> {
         read_in_all_parsed_tests(&parsed_tests_path, test_filter.clone(), variant_filter).await?;
 
     if update_persistent_state_from_upstream {
+        println!("Updating persisted test pass state from locally downloaded tests...");
+
         let t_names = parsed_tests
             .iter()
-            .flat_map(|g| g.sub_groups.iter().map(|t| t.name.as_str()));
+            .flat_map(|g| {
+                g.sub_groups
+                    .iter()
+                    .map(|sub_g| sub_g.tests.iter().map(|t| t.name.as_str()))
+            })
+            .flatten();
 
-        persistent_test_state.add_remove_entries_from_upstream_tests(t_names);
+        persistent_test_state
+            .add_remove_entries_from_upstream_tests(t_names, test_filter.is_some());
     }
 
     let test_res = match run_plonky2_tests(
@@ -83,14 +90,14 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn init_ctrl_c_handler() -> ProcessAbortedRecv {
-    // One-shot is better, but it forces us to create the channel in `main`.
-    let (send, recv) = mpsc::channel(1);
+    let aborted_bool = Arc::new(AtomicBool::new(false));
 
+    let cloned_aborted_bool = aborted_bool.clone();
     ctrlc::set_handler(move || {
-        info!("Abort signal received! Stopping currently running test...");
-        block_on(send.send(())).unwrap();
+        println!("Abort signal received! Stopping currently running test...");
+        cloned_aborted_bool.store(true, std::sync::atomic::Ordering::Relaxed);
     })
     .unwrap();
 
-    recv
+    aborted_bool
 }

--- a/evm_test_runner/src/main.rs
+++ b/evm_test_runner/src/main.rs
@@ -28,8 +28,8 @@ async fn main() -> anyhow::Result<()> {
         variant_filter,
         parsed_tests_path,
         simple_progress_indicator,
+        update_persistent_state_from_upstream,
     } = ProgArgs::parse();
-
     let mut persistent_test_state = load_existing_pass_state_from_disk_if_exists_or_create();
 
     let parsed_tests_path = parsed_tests_path
@@ -38,6 +38,15 @@ async fn main() -> anyhow::Result<()> {
 
     let parsed_tests =
         read_in_all_parsed_tests(&parsed_tests_path, test_filter.clone(), variant_filter).await?;
+
+    if update_persistent_state_from_upstream {
+        let t_names = parsed_tests
+            .iter()
+            .flat_map(|g| g.sub_groups.iter().map(|t| t.name.as_str()));
+        
+        persistent_test_state.add_remove_entries_from_upstream_tests(t_names);
+    }
+
     let test_res = run_plonky2_tests(
         parsed_tests,
         simple_progress_indicator,

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -46,7 +46,6 @@ impl TestRunEntries {
     pub(crate) fn add_remove_entries_from_upstream_tests<'a>(
         &'a mut self,
         upstream_tests: impl Iterator<Item = &'a str>,
-        filter_in_use: bool,
     ) {
         let t_names_that_are_in_upstream: HashSet<_> =
             upstream_tests.map(|s| s.to_string()).collect();
@@ -56,11 +55,6 @@ impl TestRunEntries {
             if !self.0.contains_key(upstream_k) {
                 self.0.insert(upstream_k.clone(), Default::default());
             }
-        }
-
-        if filter_in_use {
-            info!("Skipping checking for entries that may have been removed upstream due to test filters being in use...");
-            return;
         }
 
         // Remove any entries that are not longer in upstream.

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -92,7 +92,9 @@ impl From<TestStatus> for PassState {
     fn from(v: TestStatus) -> Self {
         match v {
             TestStatus::Passed => PassState::Passed,
-            TestStatus::EvmErr(_) | TestStatus::IncorrectAccountFinalState(_) => PassState::Failed,
+            TestStatus::EvmErr(_)
+            | TestStatus::IncorrectAccountFinalState(_)
+            | TestStatus::TimedOut => PassState::Failed,
         }
     }
 }

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -64,6 +64,12 @@ impl TestRunEntries {
             }
         }
     }
+
+    pub(crate) fn get_tests_that_have_passed(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().filter_map(|(name, info)| {
+            matches!(info.pass_state, PassState::Passed).then(|| name.as_str())
+        })
+    }
 }
 
 impl From<Vec<SerializableRunEntry>> for TestRunEntries {

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -11,7 +11,16 @@ const PASS_STATE_PATH_STR: &str = "test_pass_state.state";
 pub(crate) struct TestRunEntries(HashMap<String, RunEntry>);
 
 impl TestRunEntries {
-    pub(crate) fn to_serializable(self) -> Vec<SerializableRunEntry> {
+    pub(crate) fn write_to_disk(self) {
+        let data = self.to_serializable();
+        let mut writer = csv::Writer::from_path(PASS_STATE_PATH_STR).unwrap();
+
+        for entry in data {
+            writer.serialize(entry).unwrap();
+        }
+    }
+
+    fn to_serializable(self) -> Vec<SerializableRunEntry> {
         self.0
             .into_iter()
             .map(|(test_name, data)| SerializableRunEntry {

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const PASS_STATE_PATH_STR: &str = "test_pass_state.state";
+
+#[derive(Debug, Default)]
+pub(crate) struct TestRunEntries(HashMap<String, RunEntry>);
+
+impl TestRunEntries {
+    fn to_serializable(self) -> Vec<SerializableRunEntry> {
+        self.0
+            .into_iter()
+            .map(|(test_name, data)| SerializableRunEntry {
+                test_name,
+                info: RunEntry {
+                    pass_state: data.pass_state,
+                    last_run: data.last_run,
+                },
+            })
+            .collect()
+    }
+
+    fn update_test_state(&mut self, t_key: &str, state: PassState) {
+        let entry = self.0.get_mut(t_key).unwrap_or_else(|| {
+            panic!(
+                "Tried to update the pass state of the test \"{}\" but it did not exist!",
+                t_key
+            )
+        });
+        entry.pass_state = state;
+        entry.last_run = chrono::Utc::now();
+    }
+}
+
+impl From<Vec<SerializableRunEntry>> for TestRunEntries {
+    fn from(v: Vec<SerializableRunEntry>) -> Self {
+        TestRunEntries(HashMap::from_iter(
+            v.into_iter().map(|e| (e.test_name, e.info)),
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+enum PassState {
+    Passed,
+    Failed,
+    NotRun,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct SerializableRunEntry {
+    test_name: String,
+    info: RunEntry,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct RunEntry {
+    pass_state: PassState,
+    last_run: DateTime<Utc>,
+}
+
+pub(crate) fn load_existing_pass_state_from_disk_if_exists_or_create() -> TestRunEntries {
+    let mut reader = csv::Reader::from_path(PASS_STATE_PATH_STR).unwrap();
+    reader
+        .deserialize()
+        .map(|r| r.unwrap())
+        .collect::<Vec<_>>()
+        .into()
+}

--- a/evm_test_runner/src/plonky2_runner.rs
+++ b/evm_test_runner/src/plonky2_runner.rs
@@ -1,10 +1,14 @@
 //! Handles feeding the parsed tests into `plonky2` and determining the result.
 //! Essentially converts parsed tests into test results.
 
-use std::{fmt::Display, sync::atomic::Ordering, time::Duration};
+use std::{
+    fmt::{Debug, Display},
+    time::Duration,
+};
 
 use common::types::TestVariantRunInfo;
 use ethereum_types::H256;
+use futures::executor::block_on;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::trace;
 use plonky2::{
@@ -12,6 +16,7 @@ use plonky2::{
     util::timing::TimingTree,
 };
 use plonky2_evm::{all_stark::AllStark, config::StarkConfig, prover::prove_with_outputs};
+use tokio::{select, task::spawn_blocking, time::timeout};
 
 use crate::{
     persistent_run_state::TestRunEntries,
@@ -22,12 +27,13 @@ use crate::{
 
 pub(crate) type RunnerResult<T> = Result<T, ()>;
 
-trait TestProgressIndicator {
+trait TestProgressIndicator: Debug {
     fn set_current_test_name(&self, t_name: String);
     fn notify_test_completed(&mut self);
 }
 
 /// Simple test progress indicator that uses `println!`s.
+#[derive(Debug)]
 struct SimpleProgressIndicator {
     num_tests: u64,
     curr_test: usize,
@@ -48,6 +54,7 @@ impl TestProgressIndicator for SimpleProgressIndicator {
 }
 
 /// More elegant test progress indicator that uses a progress bar library.
+#[derive(Debug)]
 struct FancyProgressIndicator {
     prog_bar: ProgressBar,
 }
@@ -67,6 +74,7 @@ pub(crate) enum TestStatus {
     Passed,
     EvmErr(String),
     IncorrectAccountFinalState(TrieFinalStateDiff),
+    TimedOut,
 }
 
 impl Display for TestStatus {
@@ -77,6 +85,7 @@ impl Display for TestStatus {
             TestStatus::IncorrectAccountFinalState(diff) => {
                 write!(f, "Expected trie hash mismatch: {}", diff)
             }
+            TestStatus::TimedOut => write!(f, "Test timed out"),
         }
     }
 }
@@ -154,25 +163,39 @@ pub(crate) struct TestRunResult {
     pub(crate) status: TestStatus,
 }
 
+#[derive(Debug)]
+struct TestRunState<'a> {
+    p_indicator: Box<dyn TestProgressIndicator>,
+    persistent_test_state: &'a mut TestRunEntries,
+    process_aborted_recv: ProcessAbortedRecv,
+    test_timeout: Duration,
+}
+
 pub(crate) fn run_plonky2_tests(
     parsed_tests: Vec<ParsedTestGroup>,
     simple_progress_indicator: bool,
     persistent_test_state: &mut TestRunEntries,
-    mut process_aborted: ProcessAbortedRecv,
+    process_aborted: ProcessAbortedRecv,
+    test_timeout: Option<Duration>,
 ) -> RunnerResult<Vec<TestGroupRunResults>> {
     let num_tests = num_tests_in_groups(parsed_tests.iter());
-    let mut p_indicator = create_progress_indicator(num_tests, simple_progress_indicator);
+    let p_indicator = create_progress_indicator(num_tests, simple_progress_indicator);
+
+    let test_timeout = match test_timeout {
+        Some(t) => t,
+        None => Duration::MAX,
+    };
+
+    let mut t_state = TestRunState {
+        p_indicator,
+        persistent_test_state,
+        process_aborted_recv: process_aborted,
+        test_timeout,
+    };
 
     parsed_tests
         .into_iter()
-        .map(|g| {
-            run_test_group(
-                g,
-                &mut p_indicator,
-                persistent_test_state,
-                &mut process_aborted,
-            )
-        })
+        .map(|g| run_test_group(g, &mut t_state))
         .collect::<RunnerResult<_>>()
 }
 
@@ -200,60 +223,70 @@ fn create_progress_indicator(
 
 fn run_test_group(
     group: ParsedTestGroup,
-    p_indicator: &mut Box<dyn TestProgressIndicator>,
-    persistent_test_state: &mut TestRunEntries,
-    process_aborted: &mut ProcessAbortedRecv,
+    t_state: &mut TestRunState,
 ) -> RunnerResult<TestGroupRunResults> {
     Ok(TestGroupRunResults {
         name: group.name,
         sub_group_res: group
             .sub_groups
             .into_iter()
-            .map(|sub_g| {
-                run_test_sub_group(sub_g, p_indicator, persistent_test_state, process_aborted)
-            })
+            .map(|sub_g| run_test_sub_group(sub_g, t_state))
             .collect::<RunnerResult<_>>()?,
     })
 }
 
 fn run_test_sub_group(
     sub_group: ParsedTestSubGroup,
-    p_indicator: &mut Box<dyn TestProgressIndicator>,
-    persistent_test_state: &mut TestRunEntries,
-    process_aborted: &mut ProcessAbortedRecv,
+    t_state: &mut TestRunState,
 ) -> RunnerResult<TestSubGroupRunResults> {
     Ok(TestSubGroupRunResults {
         name: sub_group.name,
         test_res: sub_group
             .tests
             .into_iter()
-            .map(|sub_g| run_test(sub_g, p_indicator, persistent_test_state, process_aborted))
+            .map(|sub_g| run_test(sub_g, t_state))
             .collect::<RunnerResult<_>>()?,
     })
 }
 
-fn run_test(
-    test: Test,
-    p_indicator: &mut Box<dyn TestProgressIndicator>,
-    persistent_test_state: &mut TestRunEntries,
-    process_aborted: &ProcessAbortedRecv,
-) -> RunnerResult<TestRunResult> {
+fn run_test(test: Test, t_state: &mut TestRunState) -> RunnerResult<TestRunResult> {
     trace!("Running test {}...", test.name);
 
-    p_indicator.set_current_test_name(test.name.to_string());
-    let res = run_test_and_get_test_result(test.info);
+    t_state
+        .p_indicator
+        .set_current_test_name(test.name.to_string());
+    let res = run_test_or_fail_on_timeout(test.info, t_state)?;
 
-    if process_aborted.load(Ordering::Relaxed) {
-        // Stop running more tests.
-        return Err(());
-    }
-
-    persistent_test_state.update_test_state(&test.name, res.clone().into());
-    p_indicator.notify_test_completed();
+    t_state
+        .persistent_test_state
+        .update_test_state(&test.name, res.clone().into());
+    t_state.p_indicator.notify_test_completed();
 
     Ok(TestRunResult {
         name: test.name,
         status: res,
+    })
+}
+
+fn run_test_or_fail_on_timeout(
+    test: TestVariantRunInfo,
+    t_state: &mut TestRunState,
+) -> RunnerResult<TestStatus> {
+    block_on(async {
+        let proof_gen_fut = spawn_blocking(|| run_test_and_get_test_result(test));
+        let proof_gen_with_timeout_fut = timeout(t_state.test_timeout, proof_gen_fut);
+        let process_aborted_fut = t_state.process_aborted_recv.recv();
+
+        select! {
+            res = proof_gen_with_timeout_fut => {
+                match res {
+                    Ok(t_res) => Ok(t_res.unwrap()),
+                    Err(_) => Ok(TestStatus::TimedOut),
+                }
+            },
+            // Process was aborted.
+            _ = process_aborted_fut => Err(()),
+        }
     })
 }
 


### PR DESCRIPTION
# Overview
Persists minimal state between all test runs to disk in order to build up data between runs on tests that pass.

The runner now records three fields into a `csv` (`test_pass_state`) for every single test that it runs (`test_name`, `pass_state`, and `last_run`). The motivation for this is to make it easy to maintain a long list of which tests are passing/failing without having to maintain this manually.

The idea is that over time between runs, you automatically (state is always persisted regardless of flags) build up a nice database of tests that pass. Hopefully these should be in sync between everyone debugging tests, so we can also easily share this CSV with whoever is interested.

## New Flags
A handful of flags were added:

### Skip Passed (`-s --skip-passed`)
Tests that have passed at some will be skipped. Note that this applies to individual test variants.

### Test Timeout (`-t, --test-timeout`)
Set a maximum amount of time that tests can run before it's aborted and marked as a failure.

### Update Persistent State from Upstream (`-u, --update-persistent-state-from-upstream`)
On startup, scan the parsed test directory (`generation_inputs` by default) and add/remove tests from the persisted state if they have been added/removed upstream.

## Other Notes
### `SIGTERM` handler
Sending `SIGTERM` (and whatever the equivalent is on Windows) will now immediately stop the process (but still update the persisted state to disk).

### Potential for Thread Spamming
It's worth noting that when a test times out, we actually have no way to kill the thread running the test that doesn't also involve killing the owning process (the runner). This isn't a big deal when we need to `SIGTERM`, but it's a potential issue if you have a very short timeout and a rapid amount of tests failing at once. You can potentially get a huge amount of threads running tests thrashing each other for resources. One (bad) solution is to spawn each test run as a separate process, but this is a non-significant amount of work I think, and also means that we have to warm up `plonky2` each time. Other than that, I don't know how to get around this.

### Running Multiple Runners is Unsafe
I didn't bother implementing a lock file around the `csv`, so running multiple runners at once is going to get your `csv` into a weird state. I'll add concurrent test support soon, so maybe just wait for that. :slightly_smiling_face: 

### Concurrent Tests
I'm still planning on doing this, and I'll take this on once I need a break from some other project.

### Bug Fixes
Also fixed an issue where using the variant range flag was displaying the incorrect variant numbers.