### PR TITLE
Don't consider zero value in storage trie

### DIFF
--- a/eth_test_parser/src/trie_builder.rs
+++ b/eth_test_parser/src/trie_builder.rs
@@ -103,6 +103,7 @@ impl TestBody {
                 let storage_trie = pre_acc
                     .storage
                     .iter()
+                    .filter(|(_,v)| !v.is_zero())
                     .map(|(k, v)| {
                         (
                             Nibbles::from_h256_be(hash(&u256_to_be_bytes(*k))),


### PR DESCRIPTION
For some reason, some tests (e.g. `stEIP2930/storageCosts`) have a storage value set to 0. This should never happen in practice (zero value slots are deleted from the trie), so we can filter these out.