### PR TITLE
Ignore failing tests from bad gas limit config

### DIFF
--- a/evm_test_runner/src/arg_parsing.rs
+++ b/evm_test_runner/src/arg_parsing.rs
@@ -37,7 +37,8 @@ pub(crate) struct ProgArgs {
     #[arg(short = 'f', long)]
     pub(crate) test_filter: Option<String>,
 
-    /// Do not run tests that have already passed in the past.
+    /// Do not run tests that have already passed in the past or that are
+    /// ignored.
     #[arg(short = 'p', long)]
     pub(crate) skip_passed: bool,
 

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -91,6 +91,7 @@ impl From<Vec<SerializableRunEntry>> for TestRunEntries {
 #[derive(Copy, Clone, Debug, Deserialize, Default, Serialize)]
 pub(crate) enum PassState {
     Passed,
+    Ignored,
     Failed,
     #[default]
     NotRun,
@@ -100,6 +101,7 @@ impl From<TestStatus> for PassState {
     fn from(v: TestStatus) -> Self {
         match v {
             TestStatus::Passed => PassState::Passed,
+            TestStatus::Ignored => PassState::Ignored,
             TestStatus::EvmErr(_)
             | TestStatus::IncorrectAccountFinalState(_)
             | TestStatus::TimedOut => PassState::Failed,

--- a/evm_test_runner/src/persistent_run_state.rs
+++ b/evm_test_runner/src/persistent_run_state.rs
@@ -69,7 +69,7 @@ impl TestRunEntries {
 
     pub(crate) fn get_tests_that_have_passed(&self) -> impl Iterator<Item = &str> {
         self.0.iter().filter_map(|(name, info)| {
-            matches!(info.pass_state, PassState::Passed).then(|| name.as_str())
+            matches!(info.pass_state, PassState::Passed | PassState::Ignored).then(|| name.as_str())
         })
     }
 }


### PR DESCRIPTION
Not very important, but in the resulting `test_pass_state` CSV file from running the `plonky2_runner`, a lot of "Failed" results happen to arise from tests which we cannot verify because of the design choice of supporting only 32-bit gas limits. 

As such, I'm proposing to have a dedicated `TestPass` variant called `Ignored` purposedly for this failure case, to trim the number of false negatives.