### PR TITLE
Bump versions and fix broken compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,23 +19,12 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "const-random",
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
+ "const-random",
  "once_cell",
  "version_check",
 ]
@@ -48,6 +37,12 @@ checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android_system_properties"
@@ -228,15 +223,6 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
-]
-
-[[package]]
-name = "blake2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
-dependencies = [
- "digest",
 ]
 
 [[package]]
@@ -1069,11 +1055,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.6",
- "rayon",
- "serde",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1081,7 +1062,19 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+ "rayon",
  "serde",
 ]
 
@@ -1114,12 +1107,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex-literal"
@@ -1266,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1723,13 +1710,14 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plonky2"
-version = "0.1.3"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=c0abefdaf55f45fe820502688e442a5b958d1929#c0abefdaf55f45fe820502688e442a5b958d1929"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c7acc7871fdaf000d3533116eab95d89ada3dfb82b7bb0231da981323c27d6"
 dependencies = [
- "ahash 0.7.6",
+ "ahash",
  "anyhow",
  "getrandom",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "itertools",
  "keccak-hash 0.8.0",
  "log",
@@ -1747,16 +1735,15 @@ dependencies = [
 
 [[package]]
 name = "plonky2_evm"
-version = "0.1.0"
-source = "git+https://github.com/mir-protocol/plonky2.git?rev=c0abefdaf55f45fe820502688e442a5b958d1929#c0abefdaf55f45fe820502688e442a5b958d1929"
+version = "0.1.1"
+source = "git+https://github.com/mir-protocol/plonky2.git?rev=6f98fd762885e9b5343af5f0e3f0c9c90e8cf3ab#6f98fd762885e9b5343af5f0e3f0c9c90e8cf3ab"
 dependencies = [
  "anyhow",
- "blake2",
  "env_logger",
  "eth_trie_utils",
  "ethereum-types",
- "hashbrown 0.12.3",
- "hex-literal 0.3.4",
+ "hashbrown 0.14.0",
+ "hex-literal",
  "itertools",
  "jemallocator",
  "keccak-hash 0.10.0",
@@ -1781,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "plonky2_field"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0b0cfed734e8aec93ee0b49e3067a27111c355b9263fb1418bfe4c80656d12"
+checksum = "d33a655ab5d274f763c292fe7e14577f25e40d9d8607b70ef10b39f8619e60b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1797,18 +1784,18 @@ dependencies = [
 
 [[package]]
 name = "plonky2_maybe_rayon"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655cdcdb13c260cdb42b29b55247f2f66479d14342b6be3dc688efc54d3e24c4"
+checksum = "194db0cbdd974e92d897cd92b74adb3968dc1b967315eb280357c49a7637994e"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "plonky2_util"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a7f1a85a8cb948af5e47da488bd78c6d18d3d8cb25b490676f3b9f68bc5b5c8"
+checksum = "5696e2e2a6bb5c48a6e33fb0dd4d20d0a9472784b709964f337f224e99bd6d06"
 
 [[package]]
 name = "portable-atomic"
@@ -2053,7 +2040,7 @@ dependencies = [
  "fixed-hash 0.8.0",
  "hashbrown 0.13.2",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "primitive-types 0.12.1",
  "rlp",
  "ruint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,3 @@ members = [
 [profile.release]
 lto = "fat"
 codegen-units = 1
-
-# TODO: Remove once `plonky_evm` gets a version on `crates.io`...
-# Since we can only use `plonky2_evm` using a git revision (which also causes us to use `plonky2` with
-# a reivison), any deps that also use `plonky2`/`plonky2_evm` are very often going to be using imcompatable
-# revisions. We can solve this for now by using a `[patch]` section to force all deps to use a specific version,
-[patch."https://github.com/mir-protocol/plonky2.git"]
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git?rev=c0abefdaf55f45fe820502688e442a5b958d1929" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git?rev=c0abefdaf55f45fe820502688e442a5b958d1929" }
-
-[patch.crates-io]
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git?rev=c0abefdaf55f45fe820502688e442a5b958d1929" }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 ethereum-types = "0.14.1"
 eth_trie_utils = "0.6.0"
 flexi_logger = { version = "0.25.4", features = ["async"] }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "c0abefdaf55f45fe820502688e442a5b958d1929" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f98fd762885e9b5343af5f0e3f0c9c90e8cf3ab" }
 serde = {version = "1.0.163", features = ["derive"] }
 revm = { version = "3.3.0", features = ["serde"] }
 ruint = { version = "1.8.0", features = ["primitive-types"] }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -5,11 +5,13 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use eth_trie_utils::partial_trie::{HashedPartialTrie, Node, PartialTrie};
 use ethereum_types::{Address, H256};
 use plonky2_evm::{
     generation::{GenerationInputs, TrieInputs},
     proof::BlockMetadata,
 };
+use plonky2_evm::proof::TrieRoots;
 use serde::{Deserialize, Serialize};
 
 use crate::revm::SerializableEVMInstance;
@@ -58,9 +60,15 @@ impl ParsedTestManifest {
                 None => true,
             })
             .map(|(variant_idx, (t_var, revm_variant))| {
+                let trie_roots_after = TrieRoots {
+                    state_root: t_var.common.expected_final_account_state_root_hash,
+                    transactions_root: HashedPartialTrie::from(Node::Empty).hash(), // TODO: Fix this when we have transactions trie.
+                    receipts_root: HashedPartialTrie::from(Node::Empty).hash(), // TODO: Fix this when we have receipts trie.
+                };
                 let gen_inputs = GenerationInputs {
                     signed_txns: vec![t_var.txn_bytes],
                     tries: self.plonky2_variants.const_plonky2_inputs.tries.clone(),
+                    trie_roots_after,
                     contract_code: self
                         .plonky2_variants
                         .const_plonky2_inputs

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -7,11 +7,11 @@ use std::{
 use anyhow::{anyhow, Context};
 use eth_trie_utils::partial_trie::{HashedPartialTrie, Node, PartialTrie};
 use ethereum_types::{Address, H256};
+use plonky2_evm::proof::TrieRoots;
 use plonky2_evm::{
     generation::{GenerationInputs, TrieInputs},
     proof::BlockMetadata,
 };
-use plonky2_evm::proof::TrieRoots;
 use serde::{Deserialize, Serialize};
 
 use crate::revm::SerializableEVMInstance;

--- a/eth_test_parser/Cargo.toml
+++ b/eth_test_parser/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 eth_trie_utils = "0.6.0"
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "c0abefdaf55f45fe820502688e442a5b958d1929" }
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f98fd762885e9b5343af5f0e3f0c9c90e8cf3ab" }
 
 anyhow = { version = "1.0.71", features = ["backtrace"] }
 clap = {version = "4.2.7", features = ["derive"] }

--- a/evm_test_runner/Cargo.toml
+++ b/evm_test_runner/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 
 [dependencies]
 common = { path = "../common" }
-plonky2 = { git = "https://github.com/mir-protocol/plonky2.git", rev = "c0abefdaf55f45fe820502688e442a5b958d1929" }
-plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "c0abefdaf55f45fe820502688e442a5b958d1929" }
+plonky2 = "0.1.4" # NOTE: Make sure that this version matches the one used by plonky2_evm when bumping to newer versions.
+plonky2_evm = { git = "https://github.com/mir-protocol/plonky2.git", rev = "6f98fd762885e9b5343af5f0e3f0c9c90e8cf3ab" }
 
 anyhow = { version = "1.0", features = ["backtrace"] }
 askama = "0.12.0"


### PR DESCRIPTION
This PR bumps the version of plonky2 / plonky2_evm to latest version in an attempt to solve the compilation issues mentioned in #32.
In particular, only `plonky2_evm` needs to use a fixed revision, as not being on crates.io yet. We can use the matching version of `plonky2` used in `plonky2_evm` everywhere else (in that case v1.0.4).

Note that I had to cherry-pick @wborgeaud commits from #33 to make the CI pass due to those latest breaking changes.

closes #32